### PR TITLE
Restore sending queryInfo to benchto service

### DIFF
--- a/benchto-driver/src/main/java/io/trino/benchto/driver/service/BenchmarkServiceClient.java
+++ b/benchto-driver/src/main/java/io/trino/benchto/driver/service/BenchmarkServiceClient.java
@@ -279,6 +279,7 @@ public class BenchmarkServiceClient
         private Status status;
         private Instant endTime;
         private final List<Measurement> measurements = newArrayList();
+        private String queryInfo;
 
         private FinishRequest()
         {
@@ -318,6 +319,7 @@ public class BenchmarkServiceClient
 
             public FinishRequestBuilder addQueryInfo(String queryInfo)
             {
+                request.queryInfo = queryInfo;
                 return this;
             }
         }

--- a/benchto-it/pom.xml
+++ b/benchto-it/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.trino.benchto</groupId>
         <artifactId>benchto-base</artifactId>
-        <version>0.16-SNAPSHOT</version>
+        <version>0.17-SNAPSHOT</version>
     </parent>
 
     <artifactId>benchto-it</artifactId>


### PR DESCRIPTION
This got broken by some of the changes included in commit
 1b0c4f6494a4cc3c51706d2106a061bf15d2e9c1.