### PR TITLE
Fix execution for throughput test

### DIFF
--- a/benchto-it/src/test/resources/benchmarks/test_throughput_test.yaml
+++ b/benchto-it/src/test/resources/benchmarks/test_throughput_test.yaml
@@ -1,0 +1,14 @@
+datasource: test_datasource
+query-names: ${query}.sql
+query-results: test_results/${query}.result
+before-benchmark: no-op-before-benchmark
+after-benchmark: no-op-after-benchmark
+before-execution: no-op-before-execution
+after-execution: no-op-after-execution
+throughput-test: true
+prewarm-runs: 1
+concurrency: 4
+runs: 4
+variables:
+  1:
+    query: test_results

--- a/benchto-service/src/main/docker/Dockerfile
+++ b/benchto-service/src/main/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8
+FROM amazoncorretto:8
 VOLUME /tmp
 ADD benchto-service-${project.version}.jar benchto-service.jar
 RUN bash -c 'touch /benchto-service.jar'


### PR DESCRIPTION
There is a bug that makes it impossible to save benchmark results in the benchto-service. This PR resolves it.