### PR TITLE
Compatibility with JDK 11 and M1 macs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,12 +6,13 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0 # checkout tags so version in Manifest is set properly
-    - uses: actions/setup-java@v1
+    - uses: actions/setup-java@v3
       with:
-        java-version: 8
+        distribution: 'zulu'
+        java-version: 11
     - name: Maven Install Dependencies
       run: ./mvnw install -B -V -DskipTests -Dair.check.skip-all -P docker-images
     - name: Maven Test

--- a/benchto-driver/pom.xml
+++ b/benchto-driver/pom.xml
@@ -242,6 +242,17 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0-M6</version>
+                <configuration>
+                    <excludedGroups>io.trino.benchto.service.category.IntegrationTest</excludedGroups>
+                    <argLine>
+                        --add-opens java.base/java.lang=ALL-UNNAMED
+                    </argLine>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/benchto-driver/pom.xml
+++ b/benchto-driver/pom.xml
@@ -86,6 +86,10 @@
             <artifactId>snakeyaml</artifactId>
         </dependency>
         <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>javax.el</groupId>
             <artifactId>javax.el-api</artifactId>
             <scope>runtime</scope>

--- a/benchto-it/pom.xml
+++ b/benchto-it/pom.xml
@@ -136,6 +136,17 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0-M6</version>
+                <configuration>
+                    <excludedGroups>io.trino.benchto.service.category.IntegrationTest</excludedGroups>
+                    <argLine>
+                        --add-opens java.base/java.lang=ALL-UNNAMED
+                    </argLine>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/benchto-it/src/test/java/io/trino/benchto/integrationtest/BenchtoTrinoIntegrationTest.java
+++ b/benchto-it/src/test/java/io/trino/benchto/integrationtest/BenchtoTrinoIntegrationTest.java
@@ -176,7 +176,7 @@ public class BenchtoTrinoIntegrationTest
                 postgres.getDatabaseName(),
                 postgres.getUsername(),
                 postgres.getPassword());
-        service = new GenericContainer<>("prestodev/benchto-service:latest")
+        service = new GenericContainer<>("trinodev/benchto-service:latest")
                 .withNetwork(network)
                 .withNetworkAliases("benchto-service")
                 .withEnv(ImmutableMap.of("SPRING_DATASOURCE_URL", jdbcUrl))

--- a/benchto-service-docker/docker-compose.yml
+++ b/benchto-service-docker/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       - benchto-graphite
 
   benchto-service:
-    image: 'prestodev/benchto-service:${BENCHTO_SERVICE_TAG}'
+    image: 'trinodev/benchto-service:${BENCHTO_SERVICE_TAG}'
     ports:
       - '80:8080'
     links:

--- a/benchto-service/README.md
+++ b/benchto-service/README.md
@@ -70,9 +70,9 @@ Note that `description` field is optional.
 $ ./mvnw package -pl benchto-service -P docker-images
 $ docker images
 REPOSITORY                             TAG                 IMAGE ID            CREATED             VIRTUAL SIZE
-teradata-labs/benchto-service          latest              427f3e1f4777        13 seconds ago      879.3 MB
+trinodev/benchto-service               latest              427f3e1f4777        13 seconds ago      879.3 MB
 ...
-$ docker save teradata-labs/benchto-service | gzip > /tmp/benchto-service.tar.gz
+$ docker save trinodev/benchto-service | gzip > /tmp/benchto-service.tar.gz
 ```
 
 ## Cleaning up stale benchmark runs

--- a/benchto-service/pom.xml
+++ b/benchto-service/pom.xml
@@ -236,19 +236,27 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>com.spotify</groupId>
+                        <groupId>io.fabric8</groupId>
                         <artifactId>docker-maven-plugin</artifactId>
-                        <version>0.4.13</version>
+                        <version>0.40.2</version>
                         <configuration>
-                            <imageName>${docker.image.prefix}/${project.artifactId}</imageName>
-                            <dockerDirectory>${project.build.directory}/classes/docker</dockerDirectory>
-                            <resources>
-                                <resource>
-                                    <targetPath>/</targetPath>
-                                    <directory>${project.build.directory}</directory>
-                                    <include>${project.build.finalName}.jar</include>
-                                </resource>
-                            </resources>
+                            <images>
+                                <image>
+                                    <name>${docker.image.prefix}/${project.artifactId}</name>
+                                    <build>
+                                        <contextDir>${project.basedir}/src/main/docker</contextDir>
+                                        <buildx>
+                                            <platforms>
+                                                <platform>linux/amd64</platform>
+                                                <platform>linux/arm64</platform>
+                                            </platforms>
+                                        </buildx>
+                                        <assembly>
+                                            <descriptorRef>artifact</descriptorRef>
+                                        </assembly>
+                                    </build>
+                                </image>
+                            </images>
                         </configuration>
                         <executions>
                             <execution>
@@ -332,11 +340,6 @@
             <resource>
                 <directory>src/main/webapp</directory>
                 <targetPath>static</targetPath>
-            </resource>
-            <resource>
-                <directory>${basedir}/src/main/docker</directory>
-                <filtering>true</filtering>
-                <targetPath>docker</targetPath>
             </resource>
         </resources>
     </build>

--- a/benchto-service/pom.xml
+++ b/benchto-service/pom.xml
@@ -13,7 +13,7 @@
 
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
-        <docker.image.prefix>prestodev</docker.image.prefix>
+        <docker.image.prefix>trinodev</docker.image.prefix>
     </properties>
 
     <dependencies>

--- a/benchto-service/pom.xml
+++ b/benchto-service/pom.xml
@@ -170,6 +170,14 @@
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-hibernate4</artifactId>
         </dependency>
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
+        </dependency>
 
         <!-- ehcache -->
         <dependency>
@@ -290,9 +298,12 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.14</version>
+                <version>3.0.0-M6</version>
                 <configuration>
                     <excludedGroups>io.trino.benchto.service.category.IntegrationTest</excludedGroups>
+                    <argLine>
+                        --add-opens java.base/java.lang=ALL-UNNAMED
+                    </argLine>
                 </configuration>
             </plugin>
             <plugin>
@@ -315,13 +326,16 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.14</version>
+                <version>3.0.0-M7</version>
                 <configuration>
                     <includes>
                         <include>**/*.java</include>
                     </includes>
                     <groups>io.trino.benchto.service.category.IntegrationTest</groups>
-                    <argLine>-Duser.timezone=UTC</argLine>
+                    <argLine>
+                        -Duser.timezone=UTC
+                        --add-opens java.base/java.lang=ALL-UNNAMED
+                    </argLine>
                 </configuration>
                 <executions>
                     <execution>

--- a/benchto-service/src/main/docker/Dockerfile
+++ b/benchto-service/src/main/docker/Dockerfile
@@ -1,5 +1,5 @@
 FROM amazoncorretto:8
 VOLUME /tmp
-ADD benchto-service-${project.version}.jar benchto-service.jar
+ADD /maven/benchto-service-${project.version}.jar benchto-service.jar
 RUN bash -c 'touch /benchto-service.jar'
 ENTRYPOINT ["java","-Djava.security.egd=file:/dev/./urandom","-Xmx2g","-jar","/benchto-service.jar"]

--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -110,7 +110,7 @@ docker run --name benchto-service --link benchto-postgres:benchto-postgres \
         -e SPRING_DATASOURCE_URL=jdbc:postgresql://benchto-postgres:5432/postgres \
         -e SPRING_DATASOURCE_USERNAME=postgres \
         -e SPRING_DATASOURCE_PASSWORD=postgres \
-        -p 8080:8080 -d prestodev/benchto-service
+        -p 8080:8080 -d trinodev/benchto-service
 ```
 
 Verify that the benchmark service works: [http://dockerhost:8080/#/](http://dockerhost:8080/#/)

--- a/docs/getting-started/tests/.mvn/jvm.config
+++ b/docs/getting-started/tests/.mvn/jvm.config
@@ -1,0 +1,1 @@
+--add-opens java.base/java.lang=ALL-UNNAMED

--- a/docs/getting-started/tests/src/main/resources/application.yaml
+++ b/docs/getting-started/tests/src/main/resources/application.yaml
@@ -1,3 +1,7 @@
+benchmarks: src/main/resources/benchmarks
+sql: src/main/resources/sql
+query-results-dir: target/results
+
 benchmark-service:
   url: http://${dockerhost:dockerhost}:8080
 
@@ -10,6 +14,10 @@ data-sources:
 
 environment:
   name: DEMO
+
+presto:
+  url: http://$(dockerhost:dockerhost}:8081
+  username: benchto
 
 macros:
   drop-caches:

--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,7 @@
         <dep.hibernate.validator.version>5.1.3.Final</dep.hibernate.validator.version>
         <dep.aspectjweaver.version>1.8.6</dep.aspectjweaver.version>
         <dep.javax.el>2.2.4</dep.javax.el>
+        <dep.javax.xml.bind.api.version>2.3.2</dep.javax.xml.bind.api.version>
         <dep.testcontainers.version>1.16.0</dep.testcontainers.version>
     </properties>
 
@@ -260,6 +261,16 @@
                 <groupId>org.glassfish.web</groupId>
                 <artifactId>javax.el</artifactId>
                 <version>${dep.javax.el}</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.xml.bind</groupId>
+                <artifactId>jakarta.xml.bind-api</artifactId>
+                <version>${dep.javax.xml.bind.api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.glassfish.jaxb</groupId>
+                <artifactId>jaxb-runtime</artifactId>
+                <version>${dep.javax.xml.bind.api.version}</version>
             </dependency>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -61,9 +61,9 @@
         <dep.junit.version>4.12</dep.junit.version>
         <dep.hamcrest.version>2.2</dep.hamcrest.version>
         <dep.hsqldb.version>2.3.4</dep.hsqldb.version>
-        <dep.logback.version>1.1.3</dep.logback.version>
+        <dep.logback.version>1.2.11</dep.logback.version>
         <dep.postgresql.jdbc.version>9.1-901-1.jdbc4</dep.postgresql.jdbc.version>
-        <dep.slf4j.version>1.7.30</dep.slf4j.version>
+        <dep.slf4j.version>1.7.32</dep.slf4j.version>
         <dep.jadira.usertype>3.2.0.GA</dep.jadira.usertype>
         <dep.jackson.jsr310>2.4.0</dep.jackson.jsr310>
         <dep.jackson.hibernate>2.5.4</dep.jackson.hibernate>

--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,7 @@
         <dep.freemarker>2.3.22</dep.freemarker>
         <dep.mockito.version>1.10.19</dep.mockito.version>
         <dep.javax.validation.api.version>1.1.0.Final</dep.javax.validation.api.version>
+        <dep.javax.annotation.api.version>1.3.2</dep.javax.annotation.api.version>
         <dep.hibernate.version>4.3.8.Final</dep.hibernate.version>
         <dep.hibernate.jpa.version>1.0.0.Final</dep.hibernate.jpa.version>
         <dep.hibernate.validator.version>5.1.3.Final</dep.hibernate.validator.version>
@@ -219,6 +220,11 @@
                 <groupId>org.springframework.retry</groupId>
                 <artifactId>spring-retry</artifactId>
                 <version>${dep.spring.retry.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>javax.annotation</groupId>
+                <artifactId>javax.annotation-api</artifactId>
+                <version>${dep.javax.annotation.api.version}</version>
             </dependency>
             <dependency>
                 <groupId>javax.validation</groupId>


### PR DESCRIPTION
Integration tests run on JDK 17.

Regular tests run on JDK 11. Running on newer JDK would require upgrading Spring.