### PR TITLE
Normalize metrics from measurements

### DIFF
--- a/benchto-driver/src/main/java/io/trino/benchto/driver/graphite/GraphiteMetricsLoader.java
+++ b/benchto-driver/src/main/java/io/trino/benchto/driver/graphite/GraphiteMetricsLoader.java
@@ -13,6 +13,7 @@
  */
 package io.trino.benchto.driver.graphite;
 
+import com.google.common.collect.ImmutableMap;
 import io.trino.benchto.driver.Measurable;
 import io.trino.benchto.driver.execution.BenchmarkExecutionResult;
 import io.trino.benchto.driver.execution.ExecutionSynchronizer;
@@ -32,6 +33,7 @@ import javax.annotation.PostConstruct;
 
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -49,6 +51,7 @@ import static java.util.concurrent.CompletableFuture.completedFuture;
 public class GraphiteMetricsLoader
         implements PostExecutionMeasurementProvider
 {
+    private static final String METRIC_SCOPE = "cluster";
     private static final Logger LOG = LoggerFactory.getLogger(GraphiteMetricsLoader.class);
 
     @Autowired
@@ -126,7 +129,7 @@ public class GraphiteMetricsLoader
             if (metricValues.length > 0) {
                 // last non zero measurement contains total over time
                 double totalBytes = getLastValueGreaterThanZero(metricValues);
-                measurements.add(Measurement.measurement("cluster-network_total", "BYTES", totalBytes));
+                measurements.add(Measurement.measurement("network", "BYTES", totalBytes, ImmutableMap.of("scope", METRIC_SCOPE, "aggregate", "total")));
             }
         }
         return measurements;
@@ -150,8 +153,8 @@ public class GraphiteMetricsLoader
     {
         Optional<StatisticalSummary> statistics = getStats(loadedMetrics, metricName);
         if (statistics.isPresent()) {
-            measurements.add(Measurement.measurement("cluster-" + metricName + "_max", unit, statistics.get().getMax()));
-            measurements.add(Measurement.measurement("cluster-" + metricName + "_mean", unit, statistics.get().getMean()));
+            measurements.add(Measurement.measurement(metricName, unit, statistics.get().getMax(), ImmutableMap.of("scope", "cluster", "aggregate", "max")));
+            measurements.add(Measurement.measurement(metricName, unit, statistics.get().getMean(), ImmutableMap.of("scope", "cluster", "aggregate", "mean")));
         }
     }
 

--- a/benchto-driver/src/main/java/io/trino/benchto/driver/graphite/GraphiteMetricsLoader.java
+++ b/benchto-driver/src/main/java/io/trino/benchto/driver/graphite/GraphiteMetricsLoader.java
@@ -33,7 +33,6 @@ import javax.annotation.PostConstruct;
 
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -153,8 +152,8 @@ public class GraphiteMetricsLoader
     {
         Optional<StatisticalSummary> statistics = getStats(loadedMetrics, metricName);
         if (statistics.isPresent()) {
-            measurements.add(Measurement.measurement(metricName, unit, statistics.get().getMax(), ImmutableMap.of("scope", "cluster", "aggregate", "max")));
-            measurements.add(Measurement.measurement(metricName, unit, statistics.get().getMean(), ImmutableMap.of("scope", "cluster", "aggregate", "mean")));
+            measurements.add(Measurement.measurement(metricName, unit, statistics.get().getMax(), ImmutableMap.of("scope", METRIC_SCOPE, "aggregate", "max")));
+            measurements.add(Measurement.measurement(metricName, unit, statistics.get().getMean(), ImmutableMap.of("scope", METRIC_SCOPE, "aggregate", "mean")));
         }
     }
 

--- a/benchto-driver/src/main/java/io/trino/benchto/driver/listeners/measurements/DurationMeasurementProvider.java
+++ b/benchto-driver/src/main/java/io/trino/benchto/driver/listeners/measurements/DurationMeasurementProvider.java
@@ -20,6 +20,7 @@ import io.trino.benchto.driver.execution.QueryExecutionResult;
 import io.trino.benchto.driver.service.Measurement;
 import org.springframework.stereotype.Component;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
@@ -35,7 +36,11 @@ public class DurationMeasurementProvider
     {
         List<Measurement> measurements;
         if (shouldMeasureDuration(measurable)) {
-            measurements = ImmutableList.of(measurement("duration", "MILLISECONDS", measurable.getQueryDuration().toMillis()));
+            measurements = ImmutableList.of(measurement(
+                    "duration",
+                    "MILLISECONDS",
+                    measurable.getQueryDuration().toMillis(),
+                    Collections.singletonMap("scope", "driver")));
         }
         else {
             measurements = ImmutableList.of();

--- a/benchto-driver/src/main/java/io/trino/benchto/driver/listeners/measurements/ThroughputMeasurementProvider.java
+++ b/benchto-driver/src/main/java/io/trino/benchto/driver/listeners/measurements/ThroughputMeasurementProvider.java
@@ -19,6 +19,7 @@ import io.trino.benchto.driver.execution.BenchmarkExecutionResult;
 import io.trino.benchto.driver.service.Measurement;
 import org.springframework.stereotype.Component;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
@@ -34,7 +35,11 @@ public class ThroughputMeasurementProvider
     {
         List<Measurement> measurements;
         if (measurable instanceof BenchmarkExecutionResult && measurable.getBenchmark().isConcurrent() && measurable.isSuccessful()) {
-            measurements = ImmutableList.of(Measurement.measurement("throughput", "QUERY_PER_SECOND", calculateThroughput((BenchmarkExecutionResult) measurable)));
+            measurements = ImmutableList.of(Measurement.measurement(
+                    "throughput",
+                    "QUERY_PER_SECOND",
+                    calculateThroughput((BenchmarkExecutionResult) measurable),
+                    Collections.singletonMap("scope", "driver")));
         }
         else {
             measurements = emptyList();

--- a/benchto-driver/src/main/java/io/trino/benchto/driver/presto/PrestoClient.java
+++ b/benchto-driver/src/main/java/io/trino/benchto/driver/presto/PrestoClient.java
@@ -65,6 +65,7 @@ public class PrestoClient
             .put("peakTotalMemoryReservation", BYTE)
             .put("physicalWrittenDataSize", BYTE)
             .build();
+    public static final String METRIC_SCOPE = "query";
 
     @Autowired
     private RestTemplate restTemplate;
@@ -124,7 +125,7 @@ public class PrestoClient
     private Measurement parseQueryStatistic(String name, Object statistic, Unit requiredUnit)
     {
         double value = UnitConverter.parseValueAsUnit(statistic.toString(), requiredUnit);
-        return measurement(name, UnitConverter.format(requiredUnit), value, Collections.singletonMap("scope", "prestoQuery"));
+        return measurement(name, UnitConverter.format(requiredUnit), value, Collections.singletonMap("scope", METRIC_SCOPE));
     }
 
     @SuppressWarnings("unused")

--- a/benchto-driver/src/main/java/io/trino/benchto/driver/presto/PrestoClient.java
+++ b/benchto-driver/src/main/java/io/trino/benchto/driver/presto/PrestoClient.java
@@ -34,6 +34,7 @@ import org.springframework.web.util.UriComponentsBuilder;
 import javax.measure.unit.Unit;
 
 import java.net.URI;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -123,7 +124,7 @@ public class PrestoClient
     private Measurement parseQueryStatistic(String name, Object statistic, Unit requiredUnit)
     {
         double value = UnitConverter.parseValueAsUnit(statistic.toString(), requiredUnit);
-        return measurement("prestoQuery-" + name, UnitConverter.format(requiredUnit), value);
+        return measurement(name, UnitConverter.format(requiredUnit), value, Collections.singletonMap("scope", "prestoQuery"));
     }
 
     @SuppressWarnings("unused")

--- a/benchto-driver/src/main/java/io/trino/benchto/driver/service/Measurement.java
+++ b/benchto-driver/src/main/java/io/trino/benchto/driver/service/Measurement.java
@@ -15,6 +15,9 @@ package io.trino.benchto.driver.service;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 
+import java.util.Collections;
+import java.util.Map;
+
 import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.util.Objects.requireNonNull;
@@ -26,12 +29,20 @@ public class Measurement
     private String unit;
     private double value;
 
+    private Map<String, String> attributes;
+
     public static Measurement measurement(String name, String unit, double value)
+    {
+        return measurement(name, unit, value, Collections.emptyMap());
+    }
+
+    public static Measurement measurement(String name, String unit, double value, Map<String, String> attributes)
     {
         Measurement measurement = new Measurement();
         measurement.name = requireNonNull(name);
         measurement.unit = requireNonNull(unit);
         measurement.value = value;
+        measurement.attributes = attributes;
         return measurement;
     }
 
@@ -47,7 +58,7 @@ public class Measurement
 
         Measurement that = (Measurement) o;
 
-        return Double.compare(that.value, value) == 0 && name.equals(that.name) && unit.equals(that.unit);
+        return Double.compare(that.value, value) == 0 && name.equals(that.name) && unit.equals(that.unit) && attributes.equals(that.attributes);
     }
 
     @Override
@@ -59,6 +70,7 @@ public class Measurement
         result = 31 * result + unit.hashCode();
         temp = Double.doubleToLongBits(value);
         result = 31 * result + (int) (temp ^ (temp >>> 32));
+        result = 31 * result + attributes.hashCode();
         return result;
     }
 
@@ -69,6 +81,7 @@ public class Measurement
                 .add("name", name)
                 .add("unit", unit)
                 .add("value", value)
+                .add("attributes", attributes)
                 .toString();
     }
 }

--- a/benchto-driver/src/test/java/io/trino/benchto/driver/PrestoClientIntegrationTest.java
+++ b/benchto-driver/src/test/java/io/trino/benchto/driver/PrestoClientIntegrationTest.java
@@ -21,7 +21,9 @@ import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
@@ -44,20 +46,21 @@ public class PrestoClientIntegrationTest
 
         List<Measurement> measurements = prestoClient.loadMetrics("test_query_id");
 
+        Map<String, String> attributes = Collections.singletonMap("scope", "prestoQuery");
         assertThat(measurements).containsExactly(
-                Measurement.measurement("prestoQuery-analysisTime", "MILLISECONDS", 21.07),
-                Measurement.measurement("prestoQuery-planningTime", "MILLISECONDS", 24.72),
-                Measurement.measurement("prestoQuery-totalScheduledTime", "MILLISECONDS", 66000.0),
-                Measurement.measurement("prestoQuery-totalCpuTime", "MILLISECONDS", 63600.0),
-                Measurement.measurement("prestoQuery-totalBlockedTime", "MILLISECONDS", 287400.0),
-                Measurement.measurement("prestoQuery-finishingTime", "MILLISECONDS", 69000.0),
-                Measurement.measurement("prestoQuery-rawInputDataSize", "BYTES", 1.34E9),
-                Measurement.measurement("prestoQuery-processedInputDataSize", "BYTES", 7.3961E8),
-                Measurement.measurement("prestoQuery-internalNetworkInputDataSize", "BYTES", 7.2961E8),
-                Measurement.measurement("prestoQuery-physicalInputDataSize", "BYTES", 1.35E9),
-                Measurement.measurement("prestoQuery-outputDataSize", "BYTES", 6900.0),
-                Measurement.measurement("prestoQuery-peakTotalMemoryReservation", "BYTES", 6800.0),
-                Measurement.measurement("prestoQuery-physicalWrittenDataSize", "BYTES", 462265065.0));
+                Measurement.measurement("analysisTime", "MILLISECONDS", 21.07, attributes),
+                Measurement.measurement("planningTime", "MILLISECONDS", 24.72, attributes),
+                Measurement.measurement("totalScheduledTime", "MILLISECONDS", 66000.0, attributes),
+                Measurement.measurement("totalCpuTime", "MILLISECONDS", 63600.0, attributes),
+                Measurement.measurement("totalBlockedTime", "MILLISECONDS", 287400.0, attributes),
+                Measurement.measurement("finishingTime", "MILLISECONDS", 69000.0, attributes),
+                Measurement.measurement("rawInputDataSize", "BYTES", 1.34E9, attributes),
+                Measurement.measurement("processedInputDataSize", "BYTES", 7.3961E8, attributes),
+                Measurement.measurement("internalNetworkInputDataSize", "BYTES", 7.2961E8, attributes),
+                Measurement.measurement("physicalInputDataSize", "BYTES", 1.35E9, attributes),
+                Measurement.measurement("outputDataSize", "BYTES", 6900.0, attributes),
+                Measurement.measurement("peakTotalMemoryReservation", "BYTES", 6800.0, attributes),
+                Measurement.measurement("physicalWrittenDataSize", "BYTES", 462265065.0, attributes));
 
         restServiceServer.verify();
     }

--- a/benchto-driver/src/test/java/io/trino/benchto/driver/PrestoClientIntegrationTest.java
+++ b/benchto-driver/src/test/java/io/trino/benchto/driver/PrestoClientIntegrationTest.java
@@ -46,7 +46,7 @@ public class PrestoClientIntegrationTest
 
         List<Measurement> measurements = prestoClient.loadMetrics("test_query_id");
 
-        Map<String, String> attributes = Collections.singletonMap("scope", "prestoQuery");
+        Map<String, String> attributes = Collections.singletonMap("scope", "query");
         assertThat(measurements).containsExactly(
                 Measurement.measurement("analysisTime", "MILLISECONDS", 21.07, attributes),
                 Measurement.measurement("planningTime", "MILLISECONDS", 24.72, attributes),

--- a/benchto-service/src/main/java/io/trino/benchto/service/BenchmarkService.java
+++ b/benchto-service/src/main/java/io/trino/benchto/service/BenchmarkService.java
@@ -173,6 +173,8 @@ public class BenchmarkService
     private List<Measurement> normalizeMeasurements(List<FlatMeasurement> input)
     {
         // use a lookup map to avoid building a complex SQL query that compares attributes list
+        // acquire a lock to avoid adding multiple metrics with same name and same attributes
+        metricRepo.lock();
         Map<Metric, Metric> metrics = new HashMap<>();
         metricRepo.findAll().forEach(metric -> metrics.put(metric, metric));
         Map<Metric, List<FlatMeasurement>> groups = input.stream()

--- a/benchto-service/src/main/java/io/trino/benchto/service/repo/MetricRepo.java
+++ b/benchto-service/src/main/java/io/trino/benchto/service/repo/MetricRepo.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.benchto.service.repo;
+
+import io.trino.benchto.service.model.Metric;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MetricRepo
+        extends JpaRepository<Metric, Long>
+{
+}

--- a/benchto-service/src/main/java/io/trino/benchto/service/repo/MetricRepo.java
+++ b/benchto-service/src/main/java/io/trino/benchto/service/repo/MetricRepo.java
@@ -15,10 +15,13 @@ package io.trino.benchto.service.repo;
 
 import io.trino.benchto.service.model.Metric;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface MetricRepo
         extends JpaRepository<Metric, Long>
 {
+    @Query(value = "select true from pg_advisory_xact_lock(1)", nativeQuery = true)
+    void lock();
 }

--- a/benchto-service/src/main/java/io/trino/benchto/service/rest/requests/FinishRequest.java
+++ b/benchto-service/src/main/java/io/trino/benchto/service/rest/requests/FinishRequest.java
@@ -15,7 +15,6 @@ package io.trino.benchto.service.rest.requests;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import io.trino.benchto.service.model.Measurement;
 import io.trino.benchto.service.model.Status;
 
 import javax.validation.constraints.NotNull;
@@ -29,14 +28,14 @@ public class FinishRequest
     @NotNull
     private final Status status;
     private final Instant endTime;
-    private final List<Measurement> measurements;
+    private final List<FlatMeasurement> measurements;
     private final Map<String, String> attributes;
     private final String queryInfo;
 
     @JsonCreator
     public FinishRequest(@JsonProperty("status") Status status,
             @JsonProperty("endTime") Instant endTime,
-            @JsonProperty("measurements") List<Measurement> measurements,
+            @JsonProperty("measurements") List<FlatMeasurement> measurements,
             @JsonProperty("attributes") Map<String, String> attributes,
             @JsonProperty("queryInfo") String queryInfo)
     {
@@ -57,7 +56,7 @@ public class FinishRequest
         return endTime;
     }
 
-    public List<Measurement> getMeasurements()
+    public List<FlatMeasurement> getMeasurements()
     {
         return measurements;
     }

--- a/benchto-service/src/main/java/io/trino/benchto/service/rest/requests/FlatMeasurement.java
+++ b/benchto-service/src/main/java/io/trino/benchto/service/rest/requests/FlatMeasurement.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.benchto.service.rest.requests;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Map;
+
+public class FlatMeasurement
+{
+    private final String name;
+    private final String unit;
+    private final double value;
+    private final Map<String, String> attributes;
+
+    @JsonCreator
+    public FlatMeasurement(@JsonProperty("name") String name,
+            @JsonProperty("unit") String unit,
+            @JsonProperty("value") double value,
+            @JsonProperty("attributes") Map<String, String> attributes)
+    {
+        this.name = name;
+        this.unit = unit;
+        this.value = value;
+        this.attributes = attributes;
+    }
+
+    public String getName()
+    {
+        return name;
+    }
+
+    public String getUnit()
+    {
+        return unit;
+    }
+
+    public double getValue()
+    {
+        return value;
+    }
+
+    public Map<String, String> getAttributes()
+    {
+        return attributes;
+    }
+}

--- a/benchto-service/src/main/resources/db/migration/V006__metrics.sql
+++ b/benchto-service/src/main/resources/db/migration/V006__metrics.sql
@@ -1,0 +1,112 @@
+CREATE TABLE metrics
+(
+    id   BIGSERIAL PRIMARY KEY NOT NULL,
+    name VARCHAR(64)           NOT NULL,
+    unit VARCHAR(16)           NOT NULL
+);
+
+CREATE TABLE metric_attributes
+(
+    metric_id BIGINT       NOT NULL,
+    name      VARCHAR(255) NOT NULL,
+    value     VARCHAR      NOT NULL,
+    PRIMARY KEY (metric_id, name)
+);
+
+ALTER TABLE metric_attributes
+    ADD FOREIGN KEY (metric_id) REFERENCES metrics (id);
+
+INSERT INTO metrics (name, unit)
+VALUES ('network', 'BYTES'),
+       ('network', 'BYTES'),
+       ('network', 'BYTES'),
+       ('cpu', 'PERCENT'),
+       ('cpu', 'PERCENT'),
+       ('memory', 'PERCENT'),
+       ('memory', 'PERCENT'),
+       ('analysisTime', 'MILLISECONDS'),
+       ('finishingTime', 'MILLISECONDS'),
+       ('internalNetworkInputDataSize', 'BYTES'),
+       ('outputDataSize', 'BYTES'),
+       ('peakTotalMemoryReservation', 'BYTES'),
+       ('physicalInputDataSize', 'BYTES'),
+       ('physicalWrittenDataSize', 'BYTES'),
+       ('planningTime', 'MILLISECONDS'),
+       ('processedInputDataSize', 'BYTES'),
+       ('rawInputDataSize', 'BYTES'),
+       ('totalBlockedTime', 'MILLISECONDS'),
+       ('totalCpuTime', 'MILLISECONDS'),
+       ('totalScheduledTime', 'MILLISECONDS'),
+       ('duration', 'MILLISECONDS'),
+       ('throughput', 'QUERY_PER_SECOND')
+;
+
+INSERT INTO metric_attributes (metric_id, name, "value")
+SELECT id, 'scope', 'query'
+FROM metrics
+WHERE name IN (
+               'analysisTime', 'finishingTime', 'internalNetworkInputDataSize', 'outputDataSize', 'peakTotalMemoryReservation',
+               'physicalInputDataSize', 'physicalWrittenDataSize', 'planningTime', 'processedInputDataSize',
+               'rawInputDataSize', 'totalBlockedTime', 'totalCpuTime', 'totalScheduledTime');
+
+INSERT INTO metric_attributes (metric_id, name, "value")
+SELECT id, 'scope', 'cluster'
+FROM metrics
+WHERE name IN ('cpu', 'memory', 'network');
+
+INSERT INTO metric_attributes (metric_id, name, "value")
+SELECT id, 'aggregate', 'max'
+FROM metrics
+WHERE name IN ('cpu', 'memory', 'network')
+  AND id IN (SELECT min(id) FROM metrics m GROUP BY name);
+
+INSERT INTO metric_attributes (metric_id, name, "value")
+SELECT id, 'aggregate', 'mean'
+FROM metrics
+WHERE name IN ('cpu', 'memory', 'network')
+  AND id IN (SELECT min(id) FROM metrics m WHERE id NOT IN (SELECT metric_id FROM metric_attributes WHERE name = 'aggregate') GROUP BY name);
+
+INSERT INTO metric_attributes (metric_id, name, "value")
+SELECT id, 'aggregate', 'total'
+FROM metrics
+WHERE name IN ('network')
+  AND id IN (SELECT min(id) FROM metrics m WHERE id NOT IN (SELECT metric_id FROM metric_attributes WHERE name = 'aggregate') GROUP BY name);
+
+INSERT INTO metric_attributes (metric_id, name, "value")
+SELECT id, 'scope', 'driver'
+FROM metrics
+WHERE name IN ('duration', 'throughput');
+
+INSERT INTO metrics (name, unit)
+SELECT DISTINCT name, unit
+FROM measurements
+EXCEPT
+SELECT *
+FROM (SELECT name, unit
+      FROM metrics
+      UNION
+      SELECT COALESCE(scope.value || '-', '') || m.name || COALESCE('_' || aggregate.value, ''), unit
+      FROM metrics m
+               LEFT JOIN metric_attributes scope on m.id = scope.metric_id AND scope.name = 'scope' AND scope.value IN ('query', 'cluster')
+               LEFT JOIN metric_attributes aggregate on m.id = aggregate.metric_id AND aggregate.name = 'aggregate') m;
+
+ALTER TABLE measurements
+    ADD COLUMN metric_id BIGINT;
+ALTER TABLE measurements
+    ADD FOREIGN KEY (metric_id) REFERENCES metrics (id);
+
+UPDATE measurements
+SET metric_id = (SELECT m.id
+                 FROM metrics m
+                          LEFT JOIN metric_attributes scope on m.id = scope.metric_id AND scope.name = 'scope' AND scope.value IN ('query', 'cluster')
+                          LEFT JOIN metric_attributes aggregate on m.id = aggregate.metric_id AND aggregate.name = 'aggregate'
+                 WHERE COALESCE(scope.value || '-', '') || m.name || COALESCE('_' || aggregate.value, '') = measurements.name
+                   AND m.unit = measurements.unit)
+WHERE metric_id IS NULL;
+
+UPDATE measurements
+SET name = (SELECT m.name || COALESCE(' {' || NULLIF(array_to_string(array_agg(a.name || '=' || a.value ORDER BY a.name), ','), '') || '}', '')
+            FROM metrics m
+                     LEFT JOIN metric_attributes a on m.id = a.metric_id
+            WHERE m.id = measurements.metric_id
+            GROUP BY m.name);

--- a/docs/data-model/README.md
+++ b/docs/data-model/README.md
@@ -83,11 +83,13 @@ erDiagram
     }
     MEASUREMENT ||--|| BENCHMARK-RUN-MEASUREMENT : "has one"
     MEASUREMENT ||--|| EXECUTION-MEASUREMENT : "has one"
+    MEASUREMENT ||--|| METRIC : "has one"
     MEASUREMENT {
         varchar name
         varchar unit
         double value
         bigint id PK
+        bigint metric_id FK
     }
     BENCHMARK-RUN-MEASUREMENT {
         bigint benchmark_run_id PK
@@ -96,6 +98,17 @@ erDiagram
     EXECUTION-MEASUREMENT {
         bigint execution_id PK
         bigint measurement_id PK
+    }
+    METRIC ||--|{ METRIC-ATTRIBUTE : "has many"
+    METRIC {
+        varchar name
+        varchar unit
+        bigint id PK
+    }
+    METRIC-ATTRIBUTE {
+        varchar name
+        varchar value
+        bigint metric_id FK
     }
 ```
 
@@ -145,3 +158,9 @@ A measurement represents the value for a specific metric. Measurements recorded 
 can include the query duration or other statistics related to this execution.
 Measurements recorded for the whole benchmark run can include the SUT statistics or the host resource usage (CPU, memory, network, etc.).
 
+## Metric
+
+A metric represents a measurable property. Every metric should have a `scope` attribute, where the values can be:
+* `driver` for metrics measured by the driver, like `duration` and `throughput`
+* `query` for metrics related to the executed query, extracted from the server
+* `cluster` for metrics related to the whole benchmark run, extracted from an agent monitoring the cluster


### PR DESCRIPTION
This PR extracts `name` and `unit` from measurements into another `metrics` table. Such metrics also have attributes, which allow the removal of prefixes and suffixes from metric names and make it easier to filter some metrics when building reports.

The denormalized `measurement.name` and `measurement.unit` columns are not removed, but the name format is changed from `cluster-cpu_max` to `cpu {scope=cluster,aggregate=max}`.

This change matches how other metric monitoring system stores data, using labels (Prometheus) or attributes (OpenTelemetry).