### PR TITLE
Use PostgreSQL in all integration tests, instead of H2

### DIFF
--- a/benchto-service/pom.xml
+++ b/benchto-service/pom.xml
@@ -218,8 +218,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.h2database</groupId>
-            <artifactId>h2</artifactId>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>postgresql</artifactId>
+            <version>${dep.testcontainers.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/benchto-service/src/test/java/io/trino/benchto/service/CleanerServiceTest.java
+++ b/benchto-service/src/test/java/io/trino/benchto/service/CleanerServiceTest.java
@@ -48,10 +48,13 @@ public class CleanerServiceTest
     @Test
     public void cleanUpStaleBenchmarks()
     {
+        ZonedDateTime currentDate = currentDateTime();
+
         Environment environment = new Environment();
+        environment.setName("test");
+        environment.setStarted(currentDate);
         environmentRepo.save(environment);
 
-        ZonedDateTime currentDate = currentDateTime();
         BenchmarkRun staleBenchmark = new BenchmarkRun("stale benchmark test", SEQUENCE_ID, ImmutableMap.of(), UNIQUE_NAME);
         staleBenchmark.setStatus(Status.STARTED);
         staleBenchmark.setStarted(currentDate.minusHours(CleanerService.BENCHMARK_TIMEOUT_HOURS).minusMinutes(1));

--- a/benchto-service/src/test/resources/application.yaml
+++ b/benchto-service/src/test/resources/application.yaml
@@ -1,8 +1,15 @@
 spring:
+  datasource:
+    url: jdbc:tc:postgresql:11:///databasename
+    driver-class-name: org.testcontainers.jdbc.ContainerDatabaseDriver
   jpa:
-    hibernate.ddl-auto: create-drop
+    database: postgresql
+    hibernate.ddl-auto: validate
     properties:
       hibernate.cache.region.factory_class: org.hibernate.cache.ehcache.EhCacheRegionFactory
+      hibernate.cache.use_second_level_cache: true
+      hibernate.cache.use_query_cache: true
+      javax.persistence.sharedCache.mode: ENABLE_SELECTIVE
 
 flyway:
-  enabled: false
+  enabled: true


### PR DESCRIPTION
Extracted from #45, this brings the test environment much closer to production.