### PR TITLE
Save interpolated query

### DIFF
--- a/benchto-driver/src/main/java/io/trino/benchto/driver/listeners/BenchmarkServiceExecutionListener.java
+++ b/benchto-driver/src/main/java/io/trino/benchto/driver/listeners/BenchmarkServiceExecutionListener.java
@@ -138,6 +138,13 @@ public class BenchmarkServiceExecutionListener
                     if (benchmarkExecutionResult.getUtcEnd() != null) {
                         builder.withEndTime(benchmarkExecutionResult.getUtcEnd().toInstant());
                     }
+                    // Throughput tests have a different query in every execution, but only one, aggregated execution is saved
+                    // so don't save statements for them.
+                    if (!benchmarkExecutionResult.getBenchmark().isThroughputTest()) {
+                        benchmarkExecutionResult.getExecutions().stream()
+                                .findFirst()
+                                .ifPresent(e -> builder.addAttribute("statement", e.getQueryExecution().getStatement()));
+                    }
                     return builder.build();
                 })
                 .thenAccept(request -> benchmarkServiceClient.finishBenchmark(

--- a/benchto-driver/src/test/java/io/trino/benchto/driver/execution/QueryExecutionResultTest.java
+++ b/benchto-driver/src/test/java/io/trino/benchto/driver/execution/QueryExecutionResultTest.java
@@ -15,8 +15,12 @@ package io.trino.benchto.driver.execution;
 
 import io.trino.benchto.driver.Benchmark;
 import io.trino.benchto.driver.Query;
+import io.trino.benchto.driver.loader.SqlStatementGenerator;
 import org.junit.Test;
 
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -63,6 +67,12 @@ public class QueryExecutionResultTest
 
     private QueryExecution queryExecution()
     {
-        return new QueryExecution(mock(Benchmark.class), mock(Query.class), 0);
+        return new QueryExecution(mock(Benchmark.class), mock(Query.class), 0, new SqlStatementGenerator(){
+            @Override
+            public List<String> generateQuerySqlStatement(Query query, Map<String, ?> attributes)
+            {
+                return Collections.singletonList(query.getSqlTemplate());
+            }
+        });
     }
 }


### PR DESCRIPTION
Saving the executed statement will make it much easier to include it in any report generated for benchmark results. It's important to include it for anyone reading the report for the first time, or generally not being familiar with the standard benchmarks, like tpch, and how its queries are different (q01 vs q09, etc.).

This assumes that the statement is identical for every execution, so it's saved as a benchmark attribute, not execution attribute.