### PR TITLE
Save benchmark name in run attributes

### DIFF
--- a/benchto-driver/src/main/java/io/trino/benchto/driver/loader/BenchmarkDescriptor.java
+++ b/benchto-driver/src/main/java/io/trino/benchto/driver/loader/BenchmarkDescriptor.java
@@ -27,6 +27,7 @@ import static io.trino.benchto.driver.utils.YamlUtils.asStringList;
  */
 public class BenchmarkDescriptor
 {
+    public static final String NAME_KEY = "name";
     public static final String DATA_SOURCE_KEY = "datasource";
     public static final String QUERY_NAMES_KEY = "query-names";
     public static final String RUNS_KEY = "runs";
@@ -43,6 +44,7 @@ public class BenchmarkDescriptor
     public static final String QUERY_RESULTS_KEY = "query-results";
 
     public static final Set<String> RESERVED_KEYWORDS = ImmutableSet.of(
+            NAME_KEY,
             DATA_SOURCE_KEY,
             QUERY_NAMES_KEY,
             RUNS_KEY,
@@ -69,6 +71,11 @@ public class BenchmarkDescriptor
     public Map<String, String> getVariables()
     {
         return variables;
+    }
+
+    public String getName()
+    {
+        return variables.get(NAME_KEY);
     }
 
     public String getDataSource()

--- a/benchto-driver/src/test/java/io/trino/benchto/driver/loader/BenchmarkLoaderTest.java
+++ b/benchto-driver/src/test/java/io/trino/benchto/driver/loader/BenchmarkLoaderTest.java
@@ -115,6 +115,7 @@ public class BenchmarkLoaderTest
         withActiveBenchmarks("simple-benchmark");
 
         Benchmark benchmark = assertLoadedBenchmarksCount(1).get(0);
+        assertThat(benchmark.getName()).isEqualTo("different-than-filename");
         assertThat(benchmark.getQueries()).extracting("name").containsExactly("q1", "q2", "1", "2");
         assertThat(benchmark.getDataSource()).isEqualTo("foo");
         assertThat(benchmark.getRuns()).isEqualTo(3);
@@ -125,6 +126,9 @@ public class BenchmarkLoaderTest
 
         // variable overridden by profile
         assertThat(benchmark.getVariables().get("to_be_overridden")).isEqualTo("bar");
+
+        // name is in attributes, so it will be persisted in results
+        assertThat(benchmark.getVariables().get("name")).isEqualTo("different-than-filename");
     }
 
     @Test

--- a/benchto-driver/src/test/resources/unit-benchmarks/simple-benchmark.yaml
+++ b/benchto-driver/src/test/resources/unit-benchmarks/simple-benchmark.yaml
@@ -1,3 +1,4 @@
+name: different-than-filename
 to_be_overridden: 42
 datasource: foo
 before-benchmark: no-op, no-op2


### PR DESCRIPTION
Right now, we treat the query path prefix as the benchmark name. Instead, the actual benchmark name should be saved in run attributes. This PR introduces a new `name` attribute for it.