### PR TITLE
Change http client to one provided by apache.httpcomponents.client

### DIFF
--- a/benchto-driver/pom.xml
+++ b/benchto-driver/pom.xml
@@ -99,6 +99,10 @@
             <artifactId>javax.el</artifactId>
             <scope>runtime</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+        </dependency>
 
         <!-- Utils -->
         <dependency>

--- a/benchto-driver/src/main/java/io/trino/benchto/driver/DriverApp.java
+++ b/benchto-driver/src/main/java/io/trino/benchto/driver/DriverApp.java
@@ -22,6 +22,7 @@ import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
+import org.apache.http.impl.client.HttpClients;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.WebApplicationType;
@@ -35,6 +36,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.task.AsyncTaskExecutor;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.retry.annotation.EnableRetry;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
@@ -157,6 +159,7 @@ public class DriverApp
     {
         RestTemplate restTemplate = new RestTemplate();
         restTemplate.getMessageConverters().add(new MappingJackson2HttpMessageConverter());
+        restTemplate.setRequestFactory(new HttpComponentsClientHttpRequestFactory(HttpClients.createDefault()));
         return restTemplate;
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,7 @@
         <dep.hibernate.validator.version>6.2.5.Final</dep.hibernate.validator.version>
         <dep.aspectjweaver.version>1.9.9.1</dep.aspectjweaver.version>
         <dep.javax.el>2.2.5</dep.javax.el>
+        <dep.org.apache.httpcomponents.version>4.5.13</dep.org.apache.httpcomponents.version>
         <dep.jakarta.persistence.api.version>2.2.3</dep.jakarta.persistence.api.version>
         <dep.jakarta.xml.bind.api.version>2.3.3</dep.jakarta.xml.bind.api.version>
         <dep.testcontainers.version>1.17.3</dep.testcontainers.version>
@@ -293,6 +294,11 @@
                 <groupId>jakarta.persistence</groupId>
                 <artifactId>jakarta.persistence-api</artifactId>
                 <version>${dep.jakarta.persistence.api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.httpcomponents</groupId>
+                <artifactId>httpclient</artifactId>
+                <version>${dep.org.apache.httpcomponents.version}</version>
             </dependency>
             <dependency>
                 <groupId>jakarta.xml.bind</groupId>


### PR DESCRIPTION
We are observing some weird JSON parsing errors. Most probably we can exclude network issues because that problem is repeatable and happens on the application network layer (http). It could be problem at server side or client side. 
After changing the `RestTemplate`'s http client we do not observe a such problem further. 