### PR TITLE
Don't ignore values from overrides not present in base benchmark

### DIFF
--- a/benchto-driver/src/main/java/io/trino/benchto/driver/loader/BenchmarkLoader.java
+++ b/benchto-driver/src/main/java/io/trino/benchto/driver/loader/BenchmarkLoader.java
@@ -209,7 +209,7 @@ public class BenchmarkLoader
     {
         try {
             Map<Object, Object> yaml = YamlUtils.loadYamlFromPath(benchmarkFile);
-            yaml = overrideTopLevelVariables(yaml);
+            yaml = mergeTopLevelVariables(yaml);
 
             Preconditions.checkArgument(yaml.containsKey(BenchmarkDescriptor.DATA_SOURCE_KEY), "Mandatory variable %s not present in file %s", BenchmarkDescriptor.DATA_SOURCE_KEY, benchmarkFile);
             Preconditions.checkArgument(yaml.containsKey(BenchmarkDescriptor.QUERY_NAMES_KEY), "Mandatory variable %s not present in file %s", BenchmarkDescriptor.QUERY_NAMES_KEY, benchmarkFile);
@@ -247,7 +247,7 @@ public class BenchmarkLoader
         }
     }
 
-    private Map<Object, Object> overrideTopLevelVariables(Map<Object, Object> baseYaml)
+    private Map<Object, Object> mergeTopLevelVariables(Map<Object, Object> baseYaml)
     {
         ImmutableMap.Builder<Object, Object> result = ImmutableMap.builder();
         for (Map.Entry<Object, Object> entry : baseYaml.entrySet()) {
@@ -257,6 +257,13 @@ public class BenchmarkLoader
                 result.put(key, overrides.get(key));
             }
             else {
+                result.put(key, value);
+            }
+        }
+        for (Map.Entry<Object, Object> entry : overrides.entrySet()) {
+            Object key = entry.getKey();
+            Object value = entry.getValue();
+            if (!baseYaml.containsKey(key)) {
                 result.put(key, value);
             }
         }

--- a/benchto-driver/src/test/java/io/trino/benchto/driver/loader/BenchmarkLoaderTest.java
+++ b/benchto-driver/src/test/java/io/trino/benchto/driver/loader/BenchmarkLoaderTest.java
@@ -127,6 +127,9 @@ public class BenchmarkLoaderTest
         // variable overridden by profile
         assertThat(benchmark.getVariables().get("to_be_overridden")).isEqualTo("bar");
 
+        // added by profile
+        assertThat(benchmark.getVariables().get("additional")).isEqualTo("foo");
+
         // name is in attributes, so it will be persisted in results
         assertThat(benchmark.getVariables().get("name")).isEqualTo("different-than-filename");
     }

--- a/benchto-driver/src/test/resources/unit-overrides/simple-overrides.yaml
+++ b/benchto-driver/src/test/resources/unit-overrides/simple-overrides.yaml
@@ -1,1 +1,2 @@
 to_be_overridden: bar
+additional: foo


### PR DESCRIPTION
This allows adding custom attributes to benchmark runs, like the description of the cluster on which the System Under Test is running. Such a description might be specific to a single execution of the benchmark, so it can't be stored in environment attributes.