### PR TITLE
Add query-runs attribute to repeat all queries in sequence

### DIFF
--- a/benchto-driver/README.md
+++ b/benchto-driver/README.md
@@ -112,7 +112,7 @@ different variables. It is possible to use variable substitution in this file. E
 ```
 datasource: presto
 query-names: presto/linear-scan/selectivity-${selectivity}.sql
-runs: 3
+query-runs: 3
 variables:
   1:
     selectivity: 0, 2, 10, 100
@@ -132,8 +132,9 @@ List of keywords:
 |---|---|---|---|
 | datasource       | True  |       | Name of the datasource defined in `application.yaml` file.                         |
 | query-names      | True  |       | Paths to the queries.                                                              |
-| runs             | False | 3     | Number of runs each query should be executed.                                      |
-| prewarm-runs     | False | 0     | Number of prewarm runs of queries before benchmark.                                |
+| runs             | False | 3     | Number of times to execute every query.                                            |
+| query-runs       | False | 1     | Number of times to repeat all query executions.                                    |
+| prewarm-runs     | False | 0     | Number of times to repeat all query executions without storing results.            |
 | concurrency      | False | 1     | Number of concurrent workers - 1 sequential benchmark, >1 concurrency benchmark.   |
 | before-benchmark | False | none  | Names of macros executed before benchmark.                                         |
 | after-benchmark  | False | none  | Names of macros executed after benchmark.                                          |
@@ -198,6 +199,6 @@ overrides YAML file:
 
 An example overrides file:
 ```
-runs: 5
+query-runs: 5
 prewarm-runs: 10
 ```

--- a/benchto-driver/src/main/java/io/trino/benchto/driver/Benchmark.java
+++ b/benchto-driver/src/main/java/io/trino/benchto/driver/Benchmark.java
@@ -37,6 +37,7 @@ public class Benchmark
     private List<Query> queries;
     private int runs;
     private int prewarmRuns;
+    private int queryRuns;
     private int concurrency;
     private List<String> beforeBenchmarkMacros;
     private List<String> afterBenchmarkMacros;
@@ -95,6 +96,11 @@ public class Benchmark
     public int getPrewarmRuns()
     {
         return prewarmRuns;
+    }
+
+    public int getQueryRuns()
+    {
+        return queryRuns;
     }
 
     public int getConcurrency()
@@ -173,6 +179,7 @@ public class Benchmark
                         .collect(Collectors.joining(", ")))
                 .add("runs", runs)
                 .add("prewarmRuns", prewarmRuns)
+                .add("queryRuns", queryRuns)
                 .add("concurrency", concurrency)
                 .add("throughputTest", throughputTest)
                 .add("frequency", frequency)
@@ -197,6 +204,7 @@ public class Benchmark
         Benchmark benchmark = (Benchmark) o;
         return Objects.equal(runs, benchmark.runs) &&
                 Objects.equal(prewarmRuns, benchmark.prewarmRuns) &&
+                Objects.equal(queryRuns, benchmark.queryRuns) &&
                 Objects.equal(concurrency, benchmark.concurrency) &&
                 Objects.equal(name, benchmark.name) &&
                 Objects.equal(sequenceId, benchmark.sequenceId) &&
@@ -223,6 +231,7 @@ public class Benchmark
                 queries,
                 runs,
                 prewarmRuns,
+                queryRuns,
                 concurrency,
                 beforeBenchmarkMacros,
                 afterBenchmarkMacros,
@@ -267,6 +276,13 @@ public class Benchmark
         public BenchmarkBuilder withPrewarmRuns(int prewarmRuns)
         {
             this.benchmark.prewarmRuns = prewarmRuns;
+            return this;
+        }
+
+        public BenchmarkBuilder withQueryRuns(int queryRuns)
+        {
+            checkArgument(queryRuns >= 1, "Query runs must be greater of equal 1");
+            this.benchmark.queryRuns = queryRuns;
             return this;
         }
 
@@ -327,6 +343,12 @@ public class Benchmark
 
         public Benchmark build()
         {
+            // in throughput tests, runs greater than 1 are allowed only when queryRuns are 1 for backward compatibility,
+            // because queryRuns parameter was added later
+            checkArgument(!benchmark.isThroughputTest() || (
+                            (benchmark.queryRuns >= 1 && benchmark.runs == 1)
+                                    || (benchmark.queryRuns == 1 && benchmark.runs >= 1)),
+                    "In throughput tests, runs cannot be greater than 1. To set query runs greater than 1, set runs to 1.");
             return benchmark;
         }
     }

--- a/benchto-driver/src/main/java/io/trino/benchto/driver/execution/QueryExecution.java
+++ b/benchto-driver/src/main/java/io/trino/benchto/driver/execution/QueryExecution.java
@@ -30,15 +30,15 @@ public class QueryExecution
     private final Benchmark benchmark;
 
     private final Query query;
-    private final int run;
+    private final int sequenceID;
 
     private final String statement;
 
-    public QueryExecution(Benchmark benchmark, Query query, int run, SqlStatementGenerator sqlStatementGenerator)
+    public QueryExecution(Benchmark benchmark, Query query, int sequenceID, SqlStatementGenerator sqlStatementGenerator)
     {
         this.benchmark = requireNonNull(benchmark);
         this.query = requireNonNull(query);
-        this.run = run;
+        this.sequenceID = sequenceID;
 
         this.statement = generateQuerySqlStatement(sqlStatementGenerator);
     }
@@ -58,9 +58,9 @@ public class QueryExecution
         return query;
     }
 
-    public int getRun()
+    public int getSequenceID()
     {
-        return run;
+        return sequenceID;
     }
 
     public String getStatement()
@@ -73,14 +73,14 @@ public class QueryExecution
     {
         return toStringHelper(this)
                 .add("query", query)
-                .add("run", run)
+                .add("run", sequenceID)
                 .toString();
     }
 
     private String generateQuerySqlStatement(SqlStatementGenerator sqlStatementGenerator)
     {
         Map<String, String> variables = ImmutableMap.<String, String>builder()
-                .put("execution_sequence_id", Integer.toString(getRun()))
+                .put("execution_sequence_id", Integer.toString(getSequenceID()))
                 .putAll(getBenchmark().getNonReservedKeywordVariables())
                 .build();
         List<String> sqlQueries = sqlStatementGenerator.generateQuerySqlStatement(getQuery(), variables);

--- a/benchto-driver/src/main/java/io/trino/benchto/driver/listeners/BenchmarkServiceExecutionListener.java
+++ b/benchto-driver/src/main/java/io/trino/benchto/driver/listeners/BenchmarkServiceExecutionListener.java
@@ -271,7 +271,7 @@ public class BenchmarkServiceExecutionListener
 
     private String executionSequenceId(QueryExecution execution)
     {
-        return "" + execution.getRun();
+        return Integer.toString(execution.getSequenceID());
     }
 
     private static class MeasurementsWithQueryInfo

--- a/benchto-driver/src/main/java/io/trino/benchto/driver/listeners/GraphiteEventExecutionListener.java
+++ b/benchto-driver/src/main/java/io/trino/benchto/driver/listeners/GraphiteEventExecutionListener.java
@@ -89,7 +89,7 @@ public class GraphiteEventExecutionListener
         }
 
         GraphiteEventRequest request = new GraphiteEventRequestBuilder()
-                .what(format("Benchmark %s, query %s (%d) started", execution.getBenchmark().getUniqueName(), execution.getQueryName(), execution.getRun()))
+                .what(format("Benchmark %s, query %s (%d) started", execution.getBenchmark().getUniqueName(), execution.getQueryName(), execution.getSequenceID()))
                 .tags("execution", "started", execution.getBenchmark().getEnvironment())
                 .build();
 
@@ -105,7 +105,7 @@ public class GraphiteEventExecutionListener
 
         QueryExecution queryExecution = executionResult.getQueryExecution();
         GraphiteEventRequest request = new GraphiteEventRequestBuilder()
-                .what(format("Benchmark %s, query %s (%d) ended", queryExecution.getBenchmark().getUniqueName(), executionResult.getQueryName(), queryExecution.getRun()))
+                .what(format("Benchmark %s, query %s (%d) ended", queryExecution.getBenchmark().getUniqueName(), executionResult.getQueryName(), queryExecution.getSequenceID()))
                 .tags("execution", "ended", executionResult.getEnvironment())
                 .data(format("duration: %d ms", executionResult.getQueryDuration().toMillis()))
                 .when(executionResult.getUtcEnd())

--- a/benchto-driver/src/main/java/io/trino/benchto/driver/listeners/LoggingBenchmarkExecutionListener.java
+++ b/benchto-driver/src/main/java/io/trino/benchto/driver/listeners/LoggingBenchmarkExecutionListener.java
@@ -57,7 +57,10 @@ public class LoggingBenchmarkExecutionListener
     @Override
     public Future<?> executionStarted(QueryExecution execution)
     {
-        LOG.info("Query started: {} ({}/{})", execution.getQueryName(), execution.getRun(), execution.getBenchmark().getRuns());
+        LOG.info("Query started: {} ({}/{})",
+                execution.getQueryName(),
+                execution.getSequenceID(),
+                execution.getBenchmark().getQueryRuns() * execution.getBenchmark().getRuns());
 
         return CompletableFuture.completedFuture("");
     }
@@ -66,12 +69,19 @@ public class LoggingBenchmarkExecutionListener
     public Future<?> executionFinished(QueryExecutionResult result)
     {
         if (result.isSuccessful()) {
-            LOG.info("Query finished: {} ({}/{}), rows count: {}, duration: {}", result.getQueryName(), result.getQueryExecution().getRun(),
-                    result.getBenchmark().getRuns(), result.getRowsCount(), result.getQueryDuration());
+            LOG.info("Query finished: {} ({}/{}), rows count: {}, duration: {}",
+                    result.getQueryName(),
+                    result.getQueryExecution().getSequenceID(),
+                    result.getBenchmark().getQueryRuns() * result.getBenchmark().getRuns(),
+                    result.getRowsCount(),
+                    result.getQueryDuration());
         }
         else {
-            LOG.error("Query failed: {} ({}/{}), execution error: {}", result.getQueryName(), result.getQueryExecution().getRun(),
-                    result.getBenchmark().getRuns(), result.getFailureCause().getMessage());
+            LOG.error("Query failed: {} ({}/{}), execution error: {}",
+                    result.getQueryName(),
+                    result.getQueryExecution().getSequenceID(),
+                    result.getBenchmark().getQueryRuns() * result.getBenchmark().getRuns(),
+                    result.getFailureCause().getMessage());
         }
 
         return CompletableFuture.completedFuture("");

--- a/benchto-driver/src/main/java/io/trino/benchto/driver/loader/BenchmarkDescriptor.java
+++ b/benchto-driver/src/main/java/io/trino/benchto/driver/loader/BenchmarkDescriptor.java
@@ -32,6 +32,7 @@ public class BenchmarkDescriptor
     public static final String QUERY_NAMES_KEY = "query-names";
     public static final String RUNS_KEY = "runs";
     public static final String PREWARM_RUNS_KEY = "prewarm-runs";
+    public static final String QUERY_RUNS_KEY = "query-runs";
     public static final String CONCURRENCY_KEY = "concurrency";
     public static final String BEFORE_BENCHMARK_MACROS_KEY = "before-benchmark";
     public static final String AFTER_BENCHMARK_MACROS_KEY = "after-benchmark";
@@ -49,6 +50,7 @@ public class BenchmarkDescriptor
             QUERY_NAMES_KEY,
             RUNS_KEY,
             PREWARM_RUNS_KEY,
+            QUERY_RUNS_KEY,
             CONCURRENCY_KEY,
             BEFORE_BENCHMARK_MACROS_KEY,
             AFTER_BENCHMARK_MACROS_KEY,
@@ -93,9 +95,14 @@ public class BenchmarkDescriptor
         return getIntegerOptional(RUNS_KEY);
     }
 
-    public Optional<Integer> getPrewarmRepeats()
+    public Optional<Integer> getPrewarmRuns()
     {
         return getIntegerOptional(PREWARM_RUNS_KEY);
+    }
+
+    public Optional<Integer> getQueryRuns()
+    {
+        return getIntegerOptional(QUERY_RUNS_KEY);
     }
 
     public Optional<Integer> getConcurrency()

--- a/benchto-driver/src/main/java/io/trino/benchto/driver/loader/BenchmarkLoader.java
+++ b/benchto-driver/src/main/java/io/trino/benchto/driver/loader/BenchmarkLoader.java
@@ -77,6 +77,7 @@ public class BenchmarkLoader
     private static final int DEFAULT_RUNS = 3;
     private static final int DEFAULT_CONCURRENCY = 1;
     private static final int DEFAULT_PREWARM_RUNS = 0;
+    private static final int DEFAULT_QUERY_RUNS = 1;
 
     @Autowired
     private Environment environment;
@@ -226,7 +227,8 @@ public class BenchmarkLoader
                         .withDataSource(benchmarkDescriptor.getDataSource())
                         .withEnvironment(properties.getEnvironmentName())
                         .withRuns(benchmarkDescriptor.getRuns().orElse(DEFAULT_RUNS))
-                        .withPrewarmRuns(benchmarkDescriptor.getPrewarmRepeats().orElse(DEFAULT_PREWARM_RUNS))
+                        .withPrewarmRuns(benchmarkDescriptor.getPrewarmRuns().orElse(DEFAULT_PREWARM_RUNS))
+                        .withQueryRuns(benchmarkDescriptor.getQueryRuns().orElse(DEFAULT_QUERY_RUNS))
                         .withConcurrency(benchmarkDescriptor.getConcurrency().orElse(DEFAULT_CONCURRENCY))
                         .withFrequency(benchmarkDescriptor.getFrequency().map(Duration::ofDays))
                         .withThroughputTest(benchmarkDescriptor.getThroughputTest())
@@ -405,13 +407,14 @@ public class BenchmarkLoader
 
     private void printFormattedBenchmarksInfo(String formatString, Collection<Benchmark> benchmarks)
     {
-        LOGGER.info(format(formatString, "Benchmark Name", "Data Source", "Runs", "Prewarms", "Concurrency", "Throughput Test"));
+        LOGGER.info(format(formatString, "Benchmark Name", "Data Source", "Runs", "Prewarms", "Query runs", "Concurrency", "Throughput Test"));
         benchmarks.stream()
                 .map(benchmark -> format(formatString,
                         benchmark.getName(),
                         benchmark.getDataSource(),
                         benchmark.getRuns() + "",
                         benchmark.getPrewarmRuns() + "",
+                        benchmark.getQueryRuns() + "",
                         benchmark.getConcurrency() + "",
                         benchmark.isThroughputTest() + ""))
                 .distinct()

--- a/benchto-driver/src/test/java/io/trino/benchto/driver/DriverAppIntegrationTest.java
+++ b/benchto-driver/src/test/java/io/trino/benchto/driver/DriverAppIntegrationTest.java
@@ -71,8 +71,10 @@ public class DriverAppIntegrationTest
         verifyBenchmarkStart("simple_select_benchmark", "simple_select_benchmark_schema=INFORMATION_SCHEMA");
         verifySerialExecution("simple_select_benchmark_schema=INFORMATION_SCHEMA", "simple_select", 1);
         verifySerialExecution("simple_select_benchmark_schema=INFORMATION_SCHEMA", "simple_select", 2);
+        verifySerialExecution("simple_select_benchmark_schema=INFORMATION_SCHEMA", "simple_select", 3);
+        verifySerialExecution("simple_select_benchmark_schema=INFORMATION_SCHEMA", "simple_select", 4);
         verifyBenchmarkFinish("simple_select_benchmark_schema=INFORMATION_SCHEMA", ImmutableList.of());
-        verifyComplete();
+        verifyComplete(5);
     }
 
     @Test
@@ -83,7 +85,7 @@ public class DriverAppIntegrationTest
         verifySerialExecution("test_benchmark", "test_query", 1);
         verifySerialExecution("test_benchmark", "test_query", 2);
         verifyBenchmarkFinish("test_benchmark", ImmutableList.of());
-        verifyComplete();
+        verifyComplete(3);
     }
 
     @Test
@@ -229,11 +231,6 @@ public class DriverAppIntegrationTest
                 requestTo(containsString("&target=alias(integral(TARGET_NETWORK),'network_total')")),
                 method(HttpMethod.GET)
         )).andRespond(withSuccess().contentType(APPLICATION_JSON).body(GRAPHITE_METRICS_RESPONSE));
-    }
-
-    private void verifyComplete()
-    {
-        verifyComplete(3);
     }
 
     private void verifyComplete(int runs)

--- a/benchto-driver/src/test/java/io/trino/benchto/driver/loader/BenchmarkLoaderTest.java
+++ b/benchto-driver/src/test/java/io/trino/benchto/driver/loader/BenchmarkLoaderTest.java
@@ -118,11 +118,12 @@ public class BenchmarkLoaderTest
         assertThat(benchmark.getName()).isEqualTo("different-than-filename");
         assertThat(benchmark.getQueries()).extracting("name").containsExactly("q1", "q2", "1", "2");
         assertThat(benchmark.getDataSource()).isEqualTo("foo");
+        assertThat(benchmark.getPrewarmRuns()).isEqualTo(2);
         assertThat(benchmark.getRuns()).isEqualTo(3);
+        assertThat(benchmark.getQueryRuns()).isEqualTo(4);
         assertThat(benchmark.getConcurrency()).isEqualTo(1);
         assertThat(benchmark.getBeforeBenchmarkMacros()).isEqualTo(ImmutableList.of("no-op", "no-op2"));
         assertThat(benchmark.getAfterBenchmarkMacros()).isEqualTo(ImmutableList.of("no-op2"));
-        assertThat(benchmark.getPrewarmRuns()).isEqualTo(2);
 
         // variable overridden by profile
         assertThat(benchmark.getVariables().get("to_be_overridden")).isEqualTo("bar");
@@ -186,7 +187,9 @@ public class BenchmarkLoaderTest
         Benchmark benchmark = assertLoadedBenchmarksCount(1).get(0);
         assertThat(benchmark.getDataSource()).isEqualTo("foo");
         assertThat(benchmark.getQueries()).extracting("name").containsExactly("q1", "q2", "1", "2");
+        assertThat(benchmark.getPrewarmRuns()).isEqualTo(0);
         assertThat(benchmark.getRuns()).isEqualTo(10);
+        assertThat(benchmark.getQueryRuns()).isEqualTo(1);
         assertThat(benchmark.getConcurrency()).isEqualTo(20);
         assertThat(benchmark.getAfterBenchmarkMacros()).isEmpty();
         assertThat(benchmark.getBeforeBenchmarkMacros()).isEmpty();

--- a/benchto-driver/src/test/resources/benchmarks/simple_select_benchmark.yaml
+++ b/benchto-driver/src/test/resources/benchmarks/simple_select_benchmark.yaml
@@ -1,5 +1,6 @@
 datasource: test_datasource
 runs: 2
+query-runs: 2
 query-names: presto/simple_select.sql
 before-benchmark: no-op-before-benchmark, test_query_before_benchmark.sql
 after-benchmark: no-op-after-benchmark

--- a/benchto-driver/src/test/resources/unit-benchmarks/simple-benchmark.yaml
+++ b/benchto-driver/src/test/resources/unit-benchmarks/simple-benchmark.yaml
@@ -3,6 +3,8 @@ to_be_overridden: 42
 datasource: foo
 before-benchmark: no-op, no-op2
 after-benchmark: no-op2
+runs: 3
+query-runs: 1
 prewarm-runs: 2
 query-names: q1, q2, 1, 2
 frequency: 2

--- a/benchto-driver/src/test/resources/unit-overrides/simple-overrides.yaml
+++ b/benchto-driver/src/test/resources/unit-overrides/simple-overrides.yaml
@@ -1,2 +1,3 @@
+query-runs: 4
 to_be_overridden: bar
 additional: foo


### PR DESCRIPTION
Repeating the same query multiple times can yield inaccurate benchmark results because the JVM can optimize for it. This is not reflecting real-life usage. By allowing to repeat all queries in a sequence, benchmark results should better reflect the actual performance.