### PR TITLE
Multiple sequences

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/setup-java@v3
       with:
         distribution: 'zulu'
-        java-version: 11
+        java-version: 17
     - name: Maven Install Dependencies
       run: ./mvnw install -B -V -DskipTests -Dair.check.skip-all -P docker-images
     - name: Maven Test

--- a/benchto-driver/pom.xml
+++ b/benchto-driver/pom.xml
@@ -156,6 +156,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.junit.vintage</groupId>
             <artifactId>junit-vintage-engine</artifactId>
             <scope>test</scope>
@@ -211,6 +216,12 @@
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>test</scope>
+            <version>${dep.testng.version}</version>
         </dependency>
     </dependencies>
 
@@ -268,7 +279,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0-M6</version>
+                <version>${dep.plugin.surefire.version}</version>
                 <configuration>
                     <excludedGroups>io.trino.benchto.service.category.IntegrationTest</excludedGroups>
                     <argLine>

--- a/benchto-driver/src/main/java/io/trino/benchto/driver/Benchmark.java
+++ b/benchto-driver/src/main/java/io/trino/benchto/driver/Benchmark.java
@@ -245,6 +245,27 @@ public class Benchmark
             this.benchmark.queries = ImmutableList.copyOf(queries);
         }
 
+        public BenchmarkBuilder(Benchmark that, String sequenceId)
+        {
+            this.benchmark.name = that.getName();
+            this.benchmark.uniqueName = that.getUniqueName();
+            this.benchmark.sequenceId = sequenceId;
+            this.benchmark.queries = ImmutableList.copyOf(that.getQueries());
+            this.benchmark.dataSource = that.getDataSource();
+            this.benchmark.environment = that.getEnvironment();
+            this.benchmark.runs = that.getRuns();
+            this.benchmark.prewarmRuns = that.getPrewarmRuns();
+            this.benchmark.concurrency = that.getConcurrency();
+            this.benchmark.frequency = that.getFrequency();
+            this.benchmark.throughputTest = that.isThroughputTest();
+            this.benchmark.beforeBenchmarkMacros = ImmutableList.copyOf(that.getBeforeBenchmarkMacros());
+            this.benchmark.afterBenchmarkMacros = ImmutableList.copyOf(that.getAfterBenchmarkMacros());
+            this.benchmark.beforeExecutionMacros = ImmutableList.copyOf(that.getBeforeExecutionMacros());
+            this.benchmark.afterExecutionMacros = ImmutableList.copyOf(that.getAfterExecutionMacros());
+            this.benchmark.queryResults = that.getQueryResults();
+            this.benchmark.variables = ImmutableMap.copyOf(that.getVariables());
+        }
+
         public BenchmarkBuilder withDataSource(String dataSource)
         {
             this.benchmark.dataSource = dataSource;

--- a/benchto-driver/src/main/java/io/trino/benchto/driver/BenchmarkProperties.java
+++ b/benchto-driver/src/main/java/io/trino/benchto/driver/BenchmarkProperties.java
@@ -94,6 +94,9 @@ public class BenchmarkProperties
     @Value("${query-results-dir}")
     private String queryResultsDir;
 
+    @Value("${warmup:false}")
+    private String warmup;
+
     @Autowired
     private GraphiteProperties graphiteProperties;
 
@@ -213,6 +216,11 @@ public class BenchmarkProperties
         return parseBoolean(frequencyCheckEnabled);
     }
 
+    public boolean isWarmup()
+    {
+        return parseBoolean(warmup);
+    }
+
     private boolean parseBoolean(String booleanString)
     {
         if (booleanString.equalsIgnoreCase(Boolean.TRUE.toString())) {
@@ -222,7 +230,7 @@ public class BenchmarkProperties
             return false;
         }
         else {
-            throw new IllegalStateException(String.format("Incorrect boolean value: %s.", this.frequencyCheckEnabled));
+            throw new IllegalStateException(String.format("Incorrect boolean value: %s.", booleanString));
         }
     }
 }

--- a/benchto-driver/src/main/java/io/trino/benchto/driver/BenchmarkProperties.java
+++ b/benchto-driver/src/main/java/io/trino/benchto/driver/BenchmarkProperties.java
@@ -68,7 +68,7 @@ public class BenchmarkProperties
     private String activeVariables;
 
     /**
-     * Execution identifier. Should be unique between runs. If not set, it will be automatically set based on timestamp.
+     * Execution identifiers. Every value must be unique for all environments. If not set, it will be automatically set based on timestamp.
      */
     @Value("${executionSequenceId:#{null}}")
     private String executionSequenceId;
@@ -127,9 +127,9 @@ public class BenchmarkProperties
         return Optional.ofNullable(overridesPath).map(Paths::get);
     }
 
-    public Optional<String> getExecutionSequenceId()
+    public Optional<List<String>> getExecutionSequenceId()
     {
-        return Optional.ofNullable(executionSequenceId);
+        return splitProperty(executionSequenceId);
     }
 
     public String getEnvironmentName()

--- a/benchto-driver/src/main/java/io/trino/benchto/driver/DriverApp.java
+++ b/benchto-driver/src/main/java/io/trino/benchto/driver/DriverApp.java
@@ -123,6 +123,7 @@ public class DriverApp
         addOption(options, "frequencyCheckEnabled", "boolean", "if set no fresh benchmark will be executed", "true");
         addOption(options, "benchmark-service.url", "String", "URL of Benchto Service", "http://localhost:8080");
         addOption(options, "query-results-dir", "RESULTS_DIR", "directory for query results", "results");
+        addOption(options, "warmup", "boolean", "if set no benchmark results will be saved", "false");
         options.addOption("h", "help", false, "Display help message.");
         return options;
     }

--- a/benchto-driver/src/main/java/io/trino/benchto/driver/DriverApp.java
+++ b/benchto-driver/src/main/java/io/trino/benchto/driver/DriverApp.java
@@ -116,7 +116,7 @@ public class DriverApp
         addOption(options, "overrides", "PATH", "Path to benchmark overrides", "none");
         addOption(options, "activeBenchmarks", "BENCHMARK_NAME,...", "list of active benchmarks", "all benchmarks");
         addOption(options, "activeVariables", "VARIABLE_NAME=VARIABLE_VALUE,...", "list of active variables", "no filtering by variables");
-        addOption(options, "executionSequenceId", "SEQUENCE_ID", "sequence id of benchmark execution", "generated");
+        addOption(options, "executionSequenceId", "SEQUENCE_ID,...", "list of sequence ids of benchmark execution", "generated");
         addOption(options, "timeLimit", "DURATION", "amount of time while benchmarks will be executed", "unlimited");
         addOption(options, "profile", "PROFILE", "configuration profile", "none");
         addOption(options, "profiles.directory", "PROFILES_DIRECTORY", "configuration profiles directory", "none");

--- a/benchto-driver/src/main/java/io/trino/benchto/driver/execution/BenchmarkExecutionDriver.java
+++ b/benchto-driver/src/main/java/io/trino/benchto/driver/execution/BenchmarkExecutionDriver.java
@@ -242,13 +242,10 @@ public class BenchmarkExecutionDriver
                         permutedQueryIndex = queryOrder[queryIndex];
                     }
                     Query query = benchmark.getQueries().get(permutedQueryIndex);
-                    QueryExecution queryExecution = new QueryExecution(
-                            benchmark,
-                            query,
-                            queryIndex
-                                    + threadNumber * benchmark.getQueries().size()
-                                    + (run - 1) * benchmark.getConcurrency() * benchmark.getQueries().size(),
-                            sqlStatementGenerator);
+                    int sequenceId = queryIndex
+                            + threadNumber * benchmark.getQueries().size()
+                            + (run - 1) * benchmark.getConcurrency() * benchmark.getQueries().size();
+                    QueryExecution queryExecution = new QueryExecution(benchmark, query, sequenceId, sqlStatementGenerator);
                     if (firstQuery && !warmup) {
                         statusReporter.reportExecutionStarted(queryExecution);
                         firstQuery = false;

--- a/benchto-driver/src/main/java/io/trino/benchto/driver/execution/QueryExecution.java
+++ b/benchto-driver/src/main/java/io/trino/benchto/driver/execution/QueryExecution.java
@@ -30,15 +30,15 @@ public class QueryExecution
     private final Benchmark benchmark;
 
     private final Query query;
-    private final int run;
+    private final int sequenceId;
 
     private final String statement;
 
-    public QueryExecution(Benchmark benchmark, Query query, int run, SqlStatementGenerator sqlStatementGenerator)
+    public QueryExecution(Benchmark benchmark, Query query, int sequenceId, SqlStatementGenerator sqlStatementGenerator)
     {
         this.benchmark = requireNonNull(benchmark);
         this.query = requireNonNull(query);
-        this.run = run;
+        this.sequenceId = sequenceId;
 
         this.statement = generateQuerySqlStatement(sqlStatementGenerator);
     }
@@ -58,9 +58,9 @@ public class QueryExecution
         return query;
     }
 
-    public int getRun()
+    public int getSequenceId()
     {
-        return run;
+        return sequenceId;
     }
 
     public String getStatement()
@@ -73,14 +73,14 @@ public class QueryExecution
     {
         return toStringHelper(this)
                 .add("query", query)
-                .add("run", run)
+                .add("run", sequenceId)
                 .toString();
     }
 
     private String generateQuerySqlStatement(SqlStatementGenerator sqlStatementGenerator)
     {
         Map<String, String> variables = ImmutableMap.<String, String>builder()
-                .put("execution_sequence_id", Integer.toString(getRun()))
+                .put("execution_sequence_id", Integer.toString(getSequenceId()))
                 .putAll(getBenchmark().getNonReservedKeywordVariables())
                 .build();
         List<String> sqlQueries = sqlStatementGenerator.generateQuerySqlStatement(getQuery(), variables);

--- a/benchto-driver/src/main/java/io/trino/benchto/driver/listeners/BenchmarkServiceExecutionListener.java
+++ b/benchto-driver/src/main/java/io/trino/benchto/driver/listeners/BenchmarkServiceExecutionListener.java
@@ -271,7 +271,7 @@ public class BenchmarkServiceExecutionListener
 
     private String executionSequenceId(QueryExecution execution)
     {
-        return "" + execution.getRun();
+        return Integer.toString(execution.getSequenceId());
     }
 
     private static class MeasurementsWithQueryInfo

--- a/benchto-driver/src/main/java/io/trino/benchto/driver/listeners/GraphiteEventExecutionListener.java
+++ b/benchto-driver/src/main/java/io/trino/benchto/driver/listeners/GraphiteEventExecutionListener.java
@@ -89,7 +89,7 @@ public class GraphiteEventExecutionListener
         }
 
         GraphiteEventRequest request = new GraphiteEventRequestBuilder()
-                .what(format("Benchmark %s, query %s (%d) started", execution.getBenchmark().getUniqueName(), execution.getQueryName(), execution.getRun()))
+                .what(format("Benchmark %s, query %s (%d) started", execution.getBenchmark().getUniqueName(), execution.getQueryName(), execution.getSequenceId()))
                 .tags("execution", "started", execution.getBenchmark().getEnvironment())
                 .build();
 
@@ -105,7 +105,7 @@ public class GraphiteEventExecutionListener
 
         QueryExecution queryExecution = executionResult.getQueryExecution();
         GraphiteEventRequest request = new GraphiteEventRequestBuilder()
-                .what(format("Benchmark %s, query %s (%d) ended", queryExecution.getBenchmark().getUniqueName(), executionResult.getQueryName(), queryExecution.getRun()))
+                .what(format("Benchmark %s, query %s (%d) ended", queryExecution.getBenchmark().getUniqueName(), executionResult.getQueryName(), queryExecution.getSequenceId()))
                 .tags("execution", "ended", executionResult.getEnvironment())
                 .data(format("duration: %d ms", executionResult.getQueryDuration().toMillis()))
                 .when(executionResult.getUtcEnd())

--- a/benchto-driver/src/main/java/io/trino/benchto/driver/listeners/LoggingBenchmarkExecutionListener.java
+++ b/benchto-driver/src/main/java/io/trino/benchto/driver/listeners/LoggingBenchmarkExecutionListener.java
@@ -57,7 +57,10 @@ public class LoggingBenchmarkExecutionListener
     @Override
     public Future<?> executionStarted(QueryExecution execution)
     {
-        LOG.info("Query started: {} ({}/{})", execution.getQueryName(), execution.getRun(), execution.getBenchmark().getRuns());
+        LOG.info("Query started: {} ({}/{})",
+                execution.getQueryName(),
+                execution.getSequenceId(),
+                execution.getBenchmark().getRuns());
 
         return CompletableFuture.completedFuture("");
     }
@@ -66,12 +69,19 @@ public class LoggingBenchmarkExecutionListener
     public Future<?> executionFinished(QueryExecutionResult result)
     {
         if (result.isSuccessful()) {
-            LOG.info("Query finished: {} ({}/{}), rows count: {}, duration: {}", result.getQueryName(), result.getQueryExecution().getRun(),
-                    result.getBenchmark().getRuns(), result.getRowsCount(), result.getQueryDuration());
+            LOG.info("Query finished: {} ({}/{}), rows count: {}, duration: {}",
+                    result.getQueryName(),
+                    result.getQueryExecution().getSequenceId(),
+                    result.getBenchmark().getRuns(),
+                    result.getRowsCount(),
+                    result.getQueryDuration());
         }
         else {
-            LOG.error("Query failed: {} ({}/{}), execution error: {}", result.getQueryName(), result.getQueryExecution().getRun(),
-                    result.getBenchmark().getRuns(), result.getFailureCause().getMessage());
+            LOG.error("Query failed: {} ({}/{}), execution error: {}",
+                    result.getQueryName(),
+                    result.getQueryExecution().getSequenceId(),
+                    result.getBenchmark().getRuns(),
+                    result.getFailureCause().getMessage());
         }
 
         return CompletableFuture.completedFuture("");

--- a/benchto-driver/src/main/java/io/trino/benchto/driver/loader/BenchmarkDescriptor.java
+++ b/benchto-driver/src/main/java/io/trino/benchto/driver/loader/BenchmarkDescriptor.java
@@ -93,7 +93,7 @@ public class BenchmarkDescriptor
         return getIntegerOptional(RUNS_KEY);
     }
 
-    public Optional<Integer> getPrewarmRepeats()
+    public Optional<Integer> getPrewarmRuns()
     {
         return getIntegerOptional(PREWARM_RUNS_KEY);
     }

--- a/benchto-driver/src/main/java/io/trino/benchto/driver/loader/BenchmarkLoader.java
+++ b/benchto-driver/src/main/java/io/trino/benchto/driver/loader/BenchmarkLoader.java
@@ -13,7 +13,6 @@
  */
 package io.trino.benchto.driver.loader;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import freemarker.template.Configuration;
@@ -52,6 +51,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.Lists.newArrayListWithCapacity;
 import static com.google.common.collect.Maps.newHashMap;
@@ -211,8 +211,8 @@ public class BenchmarkLoader
             Map<Object, Object> yaml = YamlUtils.loadYamlFromPath(benchmarkFile);
             yaml = mergeTopLevelVariables(yaml);
 
-            Preconditions.checkArgument(yaml.containsKey(BenchmarkDescriptor.DATA_SOURCE_KEY), "Mandatory variable %s not present in file %s", BenchmarkDescriptor.DATA_SOURCE_KEY, benchmarkFile);
-            Preconditions.checkArgument(yaml.containsKey(BenchmarkDescriptor.QUERY_NAMES_KEY), "Mandatory variable %s not present in file %s", BenchmarkDescriptor.QUERY_NAMES_KEY, benchmarkFile);
+            checkArgument(yaml.containsKey(BenchmarkDescriptor.DATA_SOURCE_KEY), "Mandatory variable %s not present in file %s", BenchmarkDescriptor.DATA_SOURCE_KEY, benchmarkFile);
+            checkArgument(yaml.containsKey(BenchmarkDescriptor.QUERY_NAMES_KEY), "Mandatory variable %s not present in file %s", BenchmarkDescriptor.QUERY_NAMES_KEY, benchmarkFile);
 
             String defaultName = benchmarkName(benchmarkFile);
             List<BenchmarkDescriptor> benchmarkDescriptors = createBenchmarkDescriptors(defaultName, yaml);

--- a/benchto-driver/src/main/java/io/trino/benchto/driver/loader/BenchmarkLoader.java
+++ b/benchto-driver/src/main/java/io/trino/benchto/driver/loader/BenchmarkLoader.java
@@ -226,7 +226,7 @@ public class BenchmarkLoader
                         .withDataSource(benchmarkDescriptor.getDataSource())
                         .withEnvironment(properties.getEnvironmentName())
                         .withRuns(benchmarkDescriptor.getRuns().orElse(DEFAULT_RUNS))
-                        .withPrewarmRuns(benchmarkDescriptor.getPrewarmRepeats().orElse(DEFAULT_PREWARM_RUNS))
+                        .withPrewarmRuns(benchmarkDescriptor.getPrewarmRuns().orElse(DEFAULT_PREWARM_RUNS))
                         .withConcurrency(benchmarkDescriptor.getConcurrency().orElse(DEFAULT_CONCURRENCY))
                         .withFrequency(benchmarkDescriptor.getFrequency().map(Duration::ofDays))
                         .withThroughputTest(benchmarkDescriptor.getThroughputTest())

--- a/benchto-driver/src/test/java/io/trino/benchto/driver/execution/BenchmarkExecutionDriverTest.java
+++ b/benchto-driver/src/test/java/io/trino/benchto/driver/execution/BenchmarkExecutionDriverTest.java
@@ -15,6 +15,7 @@ package io.trino.benchto.driver.execution;
 
 import com.google.common.util.concurrent.ListeningExecutorService;
 import io.trino.benchto.driver.Benchmark;
+import io.trino.benchto.driver.BenchmarkProperties;
 import io.trino.benchto.driver.concurrent.ExecutorServiceFactory;
 import io.trino.benchto.driver.listeners.benchmark.BenchmarkStatusReporter;
 import io.trino.benchto.driver.macro.MacroService;
@@ -54,6 +55,9 @@ public class BenchmarkExecutionDriverTest
     @Mock
     ExecutionSynchronizer executionSynchronizer;
 
+    @Mock
+    BenchmarkProperties benchmarkProperties;
+
     @InjectMocks
     BenchmarkExecutionDriver driver;
 
@@ -61,6 +65,8 @@ public class BenchmarkExecutionDriverTest
     public void setUp()
     {
         when(executorServiceFactory.create(anyInt())).thenReturn(executorService);
+        when(benchmarkProperties.isWarmup())
+                .thenReturn(false);
     }
 
     @Test

--- a/benchto-driver/src/test/java/io/trino/benchto/driver/execution/ExecutionDriverTest.java
+++ b/benchto-driver/src/test/java/io/trino/benchto/driver/execution/ExecutionDriverTest.java
@@ -90,6 +90,8 @@ public class ExecutionDriverTest
                 .thenReturn(successfulBenchmarkExecution());
         when(benchmarkProperties.getTimeLimit())
                 .thenReturn(Optional.empty());
+        when(benchmarkProperties.isWarmup())
+                .thenReturn(false);
     }
 
     private BenchmarkExecutionResult successfulBenchmarkExecution()
@@ -143,6 +145,7 @@ public class ExecutionDriverTest
         ReflectionTestUtils.setField(benchmarkExecutionDriver, "executorServiceFactory", new ExecutorServiceFactory());
         ReflectionTestUtils.setField(benchmarkExecutionDriver, "executionSynchronizer", mock(ExecutionSynchronizer.class));
         ReflectionTestUtils.setField(benchmarkExecutionDriver, "statusReporter", statusReporter);
+        ReflectionTestUtils.setField(benchmarkExecutionDriver, "properties", benchmarkProperties);
         ReflectionTestUtils.setField(driver, "benchmarkExecutionDriver", benchmarkExecutionDriver);
         ReflectionTestUtils.setField(driver, "benchmarkStatusReporter", statusReporter);
 

--- a/benchto-driver/src/test/java/io/trino/benchto/driver/execution/ExecutionDriverTest.java
+++ b/benchto-driver/src/test/java/io/trino/benchto/driver/execution/ExecutionDriverTest.java
@@ -32,6 +32,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.Duration;
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
@@ -84,7 +85,7 @@ public class ExecutionDriverTest
         when(benchmarkProperties.getHealthCheckMacros())
                 .thenReturn(Optional.of(ImmutableList.of("health-check-macro")));
         when(benchmarkProperties.getExecutionSequenceId())
-                .thenReturn(Optional.of("sequence-id"));
+                .thenReturn(Optional.of(List.of("sequence-id")));
         when(benchmarkExecutionDriver.execute(any(Benchmark.class), anyInt(), anyInt(), any()))
                 .thenReturn(successfulBenchmarkExecution());
         when(benchmarkProperties.getTimeLimit())

--- a/benchto-driver/src/test/java/io/trino/benchto/driver/execution/QueryExecutionResultTest.java
+++ b/benchto-driver/src/test/java/io/trino/benchto/driver/execution/QueryExecutionResultTest.java
@@ -67,7 +67,8 @@ public class QueryExecutionResultTest
 
     private QueryExecution queryExecution()
     {
-        return new QueryExecution(mock(Benchmark.class), mock(Query.class), 0, new SqlStatementGenerator(){
+        return new QueryExecution(mock(Benchmark.class), mock(Query.class), 0, new SqlStatementGenerator()
+        {
             @Override
             public List<String> generateQuerySqlStatement(Query query, Map<String, ?> attributes)
             {

--- a/benchto-it/pom.xml
+++ b/benchto-it/pom.xml
@@ -20,36 +20,42 @@
             <groupId>io.trino.benchto</groupId>
             <artifactId>benchto-driver</artifactId>
             <version>${project.version}</version>
+            <scope>test</scope>
         </dependency>
 
         <!-- Spring -->
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-web</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-beans</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-context</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot</artifactId>
+            <scope>test</scope>
         </dependency>
 
         <!-- Utils -->
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
+            <scope>test</scope>
         </dependency>
 
         <!-- Test -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-test</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -114,10 +120,6 @@
             <artifactId>postgresql</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>net.java.dev.jna</groupId>
-            <artifactId>jna</artifactId>
-        </dependency>
     </dependencies>
 
     <build>
@@ -159,7 +161,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0-M6</version>
+                <version>${dep.plugin.surefire.version}</version>
                 <configuration>
                     <excludedGroups>io.trino.benchto.service.category.IntegrationTest</excludedGroups>
                     <argLine>

--- a/benchto-it/src/test/java/io/trino/benchto/integrationtest/BenchtoTrinoIntegrationTest.java
+++ b/benchto-it/src/test/java/io/trino/benchto/integrationtest/BenchtoTrinoIntegrationTest.java
@@ -13,6 +13,7 @@
  */
 package io.trino.benchto.integrationtest;
 
+import com.google.common.collect.ImmutableMap;
 import com.jayway.jsonpath.DocumentContext;
 import com.jayway.jsonpath.JsonPath;
 import io.trino.benchto.driver.BenchmarkProperties;
@@ -35,7 +36,6 @@ import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
-import org.testcontainers.shaded.com.google.common.collect.ImmutableMap;
 
 import java.util.List;
 import java.util.Map;

--- a/benchto-service/pom.xml
+++ b/benchto-service/pom.xml
@@ -176,14 +176,6 @@
             <groupId>jakarta.persistence</groupId>
             <artifactId>jakarta.persistence-api</artifactId>
         </dependency>
-        <dependency>
-            <groupId>jakarta.xml.bind</groupId>
-            <artifactId>jakarta.xml.bind-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish.jaxb</groupId>
-            <artifactId>jaxb-runtime</artifactId>
-        </dependency>
 
         <!-- ehcache -->
         <dependency>
@@ -197,6 +189,11 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-test</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -251,6 +248,12 @@
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest</artifactId>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>test</scope>
+            <version>${dep.testng.version}</version>
         </dependency>
     </dependencies>
 
@@ -314,9 +317,10 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0-M6</version>
+                <version>${dep.plugin.surefire.version}</version>
                 <configuration>
                     <excludedGroups>io.trino.benchto.service.category.IntegrationTest</excludedGroups>
+                    <failIfNoTests>false</failIfNoTests>
                     <argLine>
                         --add-opens java.base/java.lang=ALL-UNNAMED
                     </argLine>
@@ -336,6 +340,7 @@
                         <exclude>**/resources/banner.txt</exclude>
                         <exclude>**/resources/db/migration/*.sql</exclude>
                         <exclude>**/*.xml</exclude>
+                        <exclude>**/Dockerfile</exclude>
                     </excludes>
                 </configuration>
             </plugin>

--- a/benchto-service/src/main/docker/Dockerfile
+++ b/benchto-service/src/main/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM amazoncorretto:8
+FROM amazoncorretto:17
 VOLUME /tmp
 ADD /maven/benchto-service-${project.version}.jar benchto-service.jar
 RUN bash -c 'touch /benchto-service.jar'

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>io.airlift</groupId>
         <artifactId>airbase</artifactId>
-        <version>100</version>
+        <version>130</version>
     </parent>
 
     <inceptionYear>2015</inceptionYear>
@@ -74,14 +74,15 @@
         <dep.hibernate.version>5.6.11.Final</dep.hibernate.version>
         <dep.hibernate.validator.version>6.2.5.Final</dep.hibernate.validator.version>
         <dep.aspectjweaver.version>1.9.9.1</dep.aspectjweaver.version>
-        <dep.javax.el>2.2.5</dep.javax.el>
+        <dep.javax.el>3.0.0</dep.javax.el>
         <dep.org.apache.httpcomponents.version>4.5.13</dep.org.apache.httpcomponents.version>
         <dep.jakarta.persistence.api.version>2.2.3</dep.jakarta.persistence.api.version>
-        <dep.jakarta.xml.bind.api.version>2.3.3</dep.jakarta.xml.bind.api.version>
+        <dep.jakarta.servlet.api.version>5.0.0</dep.jakarta.servlet.api.version>
         <dep.testcontainers.version>1.17.3</dep.testcontainers.version>
         <dep.javassist.version>3.29.2-GA</dep.javassist.version>
         <dep.byte-buddy.version>1.12.17</dep.byte-buddy.version>
         <dep.jna.version>5.12.1</dep.jna.version>
+        <dep.plugin.surefire.version>3.0.0-M5</dep.plugin.surefire.version>
     </properties>
 
     <scm>
@@ -289,7 +290,7 @@
             <dependency>
                 <groupId>org.glassfish.web</groupId>
                 <artifactId>javax.el</artifactId>
-                <version>${dep.javax.el}</version>
+                <version>2.2.5</version>
             </dependency>
             <dependency>
                 <groupId>jakarta.persistence</groupId>
@@ -302,21 +303,28 @@
                 <version>${dep.org.apache.httpcomponents.version}</version>
             </dependency>
             <dependency>
-                <groupId>jakarta.xml.bind</groupId>
-                <artifactId>jakarta.xml.bind-api</artifactId>
-                <version>${dep.jakarta.xml.bind.api.version}</version>
+                <groupId>jakarta.servlet</groupId>
+                <artifactId>jakarta.servlet-api</artifactId>
+                <version>${dep.jakarta.servlet.api.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.glassfish.jaxb</groupId>
-                <artifactId>jaxb-runtime</artifactId>
-                <version>${dep.jakarta.xml.bind.api.version}</version>
+                <groupId>org.osgi</groupId>
+                <artifactId>org.osgi.core</artifactId>
+                <version>6.0.0</version>
             </dependency>
             <dependency>
-                <groupId>org.glassfish.jaxb</groupId>
-                <artifactId>txw2</artifactId>
-                <version>${dep.jakarta.xml.bind.api.version}</version>
+                <!-- used by org.springframework.boot:spring-boot-starter-data-jpa -> org.springframework.boot:spring-boot-starter-jdbc -->
+                <groupId>com.zaxxer</groupId>
+                <artifactId>HikariCP</artifactId>
+                <version>4.0.3</version>
+                <exclusions>
+                    <exclusion>
+                        <!-- it uses slf4j-api:2.0.0 which has some breaking changes compared to 1.7.36 used here -->
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>slf4j-api</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
-
 
             <!-- Drivers -->
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,7 @@
 
     <properties>
         <java.version>17</java.version>
+        <project.build.targetJdk>17</project.build.targetJdk>
 
         <encoding>UTF-8</encoding>
 


### PR DESCRIPTION
Allow specifying multiple execution identifiers (sequence id) at once. This allows repeating benchmark queries in a sequence (A B C A B C) instead of one by one (A A B B C C).

Also, add an explicit `warmup` flag for the driver, which will run all benchmarks without saving any results when enabled. This is required because `runs` can't be set to zero.

To run benchmarks in this new order, set `runs` in overrides to 1 and execute:
```
# as a warmup, run all queries twice
java -jar benchto-driver-exec.jar --warmup true --executionSequenceId 1,2
# run actual benchmarks 5 times
# sequences need to be unique, so use seconds since epoch as the prefix
seq=$(printf '%(%s)T\n' -1)
java -jar benchto-driver-exec.jar --executionSequenceId "$seq-1,$seq-2,$seq-3,$seq-4,$seq-5"
```
