### PR TITLE
Change type of column 'info' in table 'query_info' to jsonb

### DIFF
--- a/benchto-service/pom.xml
+++ b/benchto-service/pom.xml
@@ -129,6 +129,10 @@
             <artifactId>hibernate-validator</artifactId>
             <scope>runtime</scope>
         </dependency>
+        <dependency>
+            <groupId>com.vladmihalcea</groupId>
+            <artifactId>hibernate-types-52</artifactId>
+        </dependency>
 
         <!-- Logging -->
         <dependency>

--- a/benchto-service/src/main/java/io/trino/benchto/service/model/QueryInfo.java
+++ b/benchto-service/src/main/java/io/trino/benchto/service/model/QueryInfo.java
@@ -14,6 +14,9 @@
 package io.trino.benchto.service.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.vladmihalcea.hibernate.type.json.JsonBinaryType;
+import org.hibernate.annotations.Type;
+import org.hibernate.annotations.TypeDef;
 
 import javax.persistence.Cacheable;
 import javax.persistence.Column;
@@ -32,6 +35,7 @@ import static com.google.common.base.MoreObjects.toStringHelper;
 @Entity
 @Cacheable
 @Table(name = "query_info")
+@TypeDef(name = "jsonb", typeClass = JsonBinaryType.class)
 public class QueryInfo
         implements Serializable
 {
@@ -47,7 +51,8 @@ public class QueryInfo
     private long id;
 
     @NotNull
-    @Column(name = "info")
+    @Column(name = "info", columnDefinition = "jsonb")
+    @Type(type = "jsonb")
     private String info;
 
     public long getId()

--- a/benchto-service/src/main/resources/db/migration/V006__change_query_info__info_column_type.sql
+++ b/benchto-service/src/main/resources/db/migration/V006__change_query_info__info_column_type.sql
@@ -1,0 +1,1 @@
+ALTER TABLE query_info ALTER COLUMN info TYPE jsonb USING info::jsonb;

--- a/benchto-service/src/test/java/io/trino/benchto/service/BenchmarkControllerTest.java
+++ b/benchto-service/src/test/java/io/trino/benchto/service/BenchmarkControllerTest.java
@@ -138,7 +138,7 @@ public class BenchmarkControllerTest
 
         String queryInfo;
         if (sendQueryInfo) {
-            queryInfo = ", \"queryInfo\": \"{foo: \\\"bar\\\"}\"";
+            queryInfo = ", \"queryInfo\": \"{\\\"foo\\\": \\\"bar\\\"}\"";
         }
         else {
             queryInfo = "";
@@ -248,7 +248,7 @@ public class BenchmarkControllerTest
                     .isBefore(testEnd);
 
             if (sendQueryInfo) {
-                assertThat(execution.getQueryInfo().getInfo()).isEqualTo("{foo: \"bar\"}");
+                assertThat(execution.getQueryInfo().getInfo()).isEqualTo("{\"foo\": \"bar\"}");
             }
         });
     }

--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,7 @@
         <dep.javax.annotation.api.version>1.3.2</dep.javax.annotation.api.version>
         <dep.hibernate.version>5.6.11.Final</dep.hibernate.version>
         <dep.hibernate.validator.version>6.2.5.Final</dep.hibernate.validator.version>
+        <dep.hibernate-types-52.version>2.20.0</dep.hibernate-types-52.version>
         <dep.aspectjweaver.version>1.9.9.1</dep.aspectjweaver.version>
         <dep.javax.el>2.2.5</dep.javax.el>
         <dep.jakarta.persistence.api.version>2.2.3</dep.jakarta.persistence.api.version>
@@ -278,6 +279,11 @@
                 <groupId>org.hibernate</groupId>
                 <artifactId>hibernate-validator</artifactId>
                 <version>${dep.hibernate.validator.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.vladmihalcea</groupId>
+                <artifactId>hibernate-types-52</artifactId>
+                <version>${dep.hibernate-types-52.version}</version>
             </dependency>
             <dependency>
                 <groupId>javax.el</groupId>


### PR DESCRIPTION
The column 'info' in the table 'query_info' has a type 'text'. This column stores only json documents so it is reasonable to change type of this column to jsonb.