### PR TITLE
Repeat query combinations instead of every query

### DIFF
--- a/benchto-driver/src/test/java/io/trino/benchto/driver/execution/BenchmarkExecutionDriverTest.java
+++ b/benchto-driver/src/test/java/io/trino/benchto/driver/execution/BenchmarkExecutionDriverTest.java
@@ -16,8 +16,10 @@ package io.trino.benchto.driver.execution;
 import com.google.common.util.concurrent.ListeningExecutorService;
 import io.trino.benchto.driver.Benchmark;
 import io.trino.benchto.driver.BenchmarkProperties;
+import io.trino.benchto.driver.Query;
 import io.trino.benchto.driver.concurrent.ExecutorServiceFactory;
 import io.trino.benchto.driver.listeners.benchmark.BenchmarkStatusReporter;
+import io.trino.benchto.driver.loader.SqlStatementGenerator;
 import io.trino.benchto.driver.macro.MacroService;
 import org.junit.Before;
 import org.junit.Test;
@@ -26,12 +28,15 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -61,21 +66,31 @@ public class BenchmarkExecutionDriverTest
     @InjectMocks
     BenchmarkExecutionDriver driver;
 
+    @Mock
+    SqlStatementGenerator sqlStatementGenerator;
+
     @Before
     public void setUp()
     {
         when(executorServiceFactory.create(anyInt())).thenReturn(executorService);
         when(benchmarkProperties.isWarmup())
                 .thenReturn(false);
+        when(sqlStatementGenerator.generateQuerySqlStatement(any(Query.class), anyMap())).thenReturn(List.of("SELECT 1"));
     }
 
     @Test
     public void successfulRun()
     {
-        BenchmarkExecutionResult benchmarkExecutionResult = driver.execute(mock(Benchmark.class), 0, 0, Optional.empty());
+        Benchmark benchmark = mock(Benchmark.class);
+        when(benchmark.getRuns()).thenReturn(1);
+        when(benchmark.getConcurrency()).thenReturn(1);
+        when(benchmark.getQueries()).thenReturn(List.of(new Query("fake-query", "SELECT 1", Map.of())));
+        List<BenchmarkExecutionResult> results = driver.execute(List.of(benchmark), 0, 0, Optional.empty());
 
-        assertThat(benchmarkExecutionResult.getFailureCauses()).isEmpty();
-        assertThat(benchmarkExecutionResult.isSuccessful()).isTrue();
+        results.forEach(result -> {
+            assertThat(result.getFailureCauses()).isEmpty();
+            assertThat(result.isSuccessful()).isTrue();
+        });
     }
 
     @Test
@@ -85,10 +100,12 @@ public class BenchmarkExecutionDriverTest
         doNothing().doThrow(afterMacroException)
                 .when(macroService).runBenchmarkMacros(anyList(), any(Benchmark.class));
 
-        BenchmarkExecutionResult benchmarkExecutionResult = driver.execute(mock(Benchmark.class), 0, 0, Optional.empty());
+        List<BenchmarkExecutionResult> results = driver.execute(List.of(mock(Benchmark.class)), 0, 0, Optional.empty());
 
-        assertThat(benchmarkExecutionResult.isSuccessful()).isFalse();
-        assertThat(benchmarkExecutionResult.getFailureCauses()).containsExactly(afterMacroException);
+        results.forEach(result -> {
+            assertThat(result.isSuccessful()).isFalse();
+            assertThat(result.getFailureCauses()).containsExactly(afterMacroException);
+        });
     }
 
     @Test
@@ -98,9 +115,11 @@ public class BenchmarkExecutionDriverTest
         doThrow(executorServiceException)
                 .when(executorServiceFactory).create(anyInt());
 
-        BenchmarkExecutionResult benchmarkExecutionResult = driver.execute(mock(Benchmark.class), 0, 0, Optional.empty());
+        List<BenchmarkExecutionResult> results = driver.execute(List.of(mock(Benchmark.class)), 0, 0, Optional.empty());
 
-        assertThat(benchmarkExecutionResult.isSuccessful()).isFalse();
-        assertThat(benchmarkExecutionResult.getFailureCauses()).containsExactly(executorServiceException);
+        results.forEach(result -> {
+            assertThat(result.isSuccessful()).isFalse();
+            assertThat(result.getFailureCauses()).containsExactly(executorServiceException);
+        });
     }
 }

--- a/benchto-driver/src/test/java/io/trino/benchto/driver/execution/ExecutionDriverTest.java
+++ b/benchto-driver/src/test/java/io/trino/benchto/driver/execution/ExecutionDriverTest.java
@@ -74,6 +74,7 @@ public class ExecutionDriverTest
     public void setUp()
     {
         Benchmark benchmark = mock(Benchmark.class);
+        when(benchmark.getName()).thenReturn("mock");
         when(benchmark.getConcurrency()).thenReturn(1);
 
         when(benchmarkLoader.loadBenchmarks(anyString()))
@@ -86,7 +87,7 @@ public class ExecutionDriverTest
                 .thenReturn(Optional.of(ImmutableList.of("health-check-macro")));
         when(benchmarkProperties.getExecutionSequenceId())
                 .thenReturn(Optional.of(List.of("sequence-id")));
-        when(benchmarkExecutionDriver.execute(any(Benchmark.class), anyInt(), anyInt(), any()))
+        when(benchmarkExecutionDriver.execute(anyList(), anyInt(), anyInt(), any()))
                 .thenReturn(successfulBenchmarkExecution());
         when(benchmarkProperties.getTimeLimit())
                 .thenReturn(Optional.empty());
@@ -94,9 +95,12 @@ public class ExecutionDriverTest
                 .thenReturn(false);
     }
 
-    private BenchmarkExecutionResult successfulBenchmarkExecution()
+    private List<BenchmarkExecutionResult> successfulBenchmarkExecution()
     {
-        return new BenchmarkExecutionResult.BenchmarkExecutionResultBuilder(null).withExecutions(ImmutableList.of()).build();
+        BenchmarkExecutionResult result = new BenchmarkExecutionResult.BenchmarkExecutionResultBuilder(null)
+                .withExecutions(ImmutableList.of())
+                .build();
+        return List.of(result);
     }
 
     @Test
@@ -119,7 +123,7 @@ public class ExecutionDriverTest
 
         driver.execute();
 
-        verify(benchmarkExecutionDriver).execute(any(Benchmark.class), anyInt(), anyInt(), any());
+        verify(benchmarkExecutionDriver).execute(anyList(), anyInt(), anyInt(), any());
         verifyNoMoreInteractions(benchmarkExecutionDriver);
     }
 


### PR DESCRIPTION
This changes the order of execution of benchmark queries, where instead of immediately repeating every query, all queries for a combination of variables of a benchmark are repeated in a sequence. This includes warmup queries.

Throughput tests execution order is not affected.

If there's an unexpected exception, results for all combinations of a benchmark are annotated with it.

The main idea is to group benchmark combinations and pass them down so they're executed in the same executor. Lots of methods now accept a `List<Benchmark>`, where it can be a single item or a group. There are a few new assertions to make sure that parameters like `runs` and `concurrency` have the same value for all benchmarks in a group.

When executions are returned, they're grouped by benchmark again to create results.