### PR TITLE
Add repeatLevel parameter to control what part of benchmark should be repeated

### DIFF
--- a/benchto-driver/src/main/java/io/trino/benchto/driver/BenchmarkProperties.java
+++ b/benchto-driver/src/main/java/io/trino/benchto/driver/BenchmarkProperties.java
@@ -79,6 +79,9 @@ public class BenchmarkProperties
     @Value("${macroExecutions.healthCheck:#{null}}")
     private String healthCheckMacros;
 
+    @Value("${queryRepetitionScope:BENCHMARK}")
+    private QueryRepetitionScope queryRepetitionScope;
+
     @Value("${macroExecutions.beforeAll:#{null}}")
     private String beforeAllMacros;
 
@@ -171,6 +174,11 @@ public class BenchmarkProperties
         return Paths.get(queryResultsDir);
     }
 
+    public QueryRepetitionScope getQueryRepetitionScope()
+    {
+        return queryRepetitionScope;
+    }
+
     @Override
     public String toString()
     {
@@ -232,5 +240,10 @@ public class BenchmarkProperties
         else {
             throw new IllegalStateException(String.format("Incorrect boolean value: %s.", booleanString));
         }
+    }
+
+    public enum QueryRepetitionScope {
+        BENCHMARK, // repeat queries within benchmark run
+        SUITE // repeat queries within entire suite execution
     }
 }

--- a/benchto-driver/src/test/resources/benchmarks/benchmark_with_2_queries.yaml
+++ b/benchto-driver/src/test/resources/benchmarks/benchmark_with_2_queries.yaml
@@ -1,0 +1,12 @@
+datasource: test_datasource
+runs: 2
+query-names: presto/${query}.sql, presto/simple_select_2.sql
+before-benchmark: no-op-before-benchmark, test_query_before_benchmark.sql
+after-benchmark: no-op-after-benchmark
+before-execution: no-op-before-execution
+after-execution: no-op-after-execution
+prewarm-runs: 0
+variables:
+  1:
+    schema: INFORMATION_SCHEMA
+    query: simple_select, simple_select_2

--- a/benchto-driver/src/test/resources/sql/presto/simple_select_2.sql
+++ b/benchto-driver/src/test/resources/sql/presto/simple_select_2.sql
@@ -1,0 +1,1 @@
+SELECT 2 FROM "${schema}".SYSTEM_USERS


### PR DESCRIPTION
The parameter `repeatLevel` adds possibility to choose whether benchmark or particular query should be repeated i.e. run multiple times to make an measurement. This parameter accepts two values: `BENCHMARK` and `QUERY`.