### PR TITLE
Add query-runs to BenchmarkDescriptor 

### DIFF
--- a/benchto-driver/src/main/java/io/trino/benchto/driver/Benchmark.java
+++ b/benchto-driver/src/main/java/io/trino/benchto/driver/Benchmark.java
@@ -36,6 +36,7 @@ public class Benchmark
     private String environment;
     private List<Query> queries;
     private int runs;
+    private int queryRuns;
     private int prewarmRuns;
     private int concurrency;
     private List<String> beforeBenchmarkMacros;
@@ -90,6 +91,11 @@ public class Benchmark
     public int getRuns()
     {
         return runs;
+    }
+
+    public int getQueryRuns()
+    {
+        return queryRuns;
     }
 
     public int getPrewarmRuns()
@@ -172,6 +178,7 @@ public class Benchmark
                         .map(Query::getName)
                         .collect(Collectors.joining(", ")))
                 .add("runs", runs)
+                .add("queryRuns", queryRuns)
                 .add("prewarmRuns", prewarmRuns)
                 .add("concurrency", concurrency)
                 .add("throughputTest", throughputTest)
@@ -196,6 +203,7 @@ public class Benchmark
         }
         Benchmark benchmark = (Benchmark) o;
         return Objects.equal(runs, benchmark.runs) &&
+                Objects.equal(queryRuns, benchmark.queryRuns) &&
                 Objects.equal(prewarmRuns, benchmark.prewarmRuns) &&
                 Objects.equal(concurrency, benchmark.concurrency) &&
                 Objects.equal(name, benchmark.name) &&
@@ -222,6 +230,7 @@ public class Benchmark
                 environment,
                 queries,
                 runs,
+                queryRuns,
                 prewarmRuns,
                 concurrency,
                 beforeBenchmarkMacros,
@@ -254,6 +263,7 @@ public class Benchmark
             this.benchmark.dataSource = that.getDataSource();
             this.benchmark.environment = that.getEnvironment();
             this.benchmark.runs = that.getRuns();
+            this.benchmark.queryRuns = that.getQueryRuns();
             this.benchmark.prewarmRuns = that.getPrewarmRuns();
             this.benchmark.concurrency = that.getConcurrency();
             this.benchmark.frequency = that.getFrequency();
@@ -282,6 +292,13 @@ public class Benchmark
         {
             checkArgument(runs >= 1, "Runs must be greater of equal 1");
             this.benchmark.runs = runs;
+            return this;
+        }
+
+        public BenchmarkBuilder withQueryRuns(int queryRuns)
+        {
+            checkArgument(queryRuns >= 1, "queryRuns must be greater of equal 1");
+            this.benchmark.queryRuns = queryRuns;
             return this;
         }
 

--- a/benchto-driver/src/main/java/io/trino/benchto/driver/listeners/LoggingBenchmarkExecutionListener.java
+++ b/benchto-driver/src/main/java/io/trino/benchto/driver/listeners/LoggingBenchmarkExecutionListener.java
@@ -60,7 +60,7 @@ public class LoggingBenchmarkExecutionListener
         LOG.info("Query started: {} ({}/{})",
                 execution.getQueryName(),
                 execution.getSequenceId(),
-                execution.getBenchmark().getRuns());
+                execution.getBenchmark().getRuns() * execution.getBenchmark().getQueryRuns());
 
         return CompletableFuture.completedFuture("");
     }
@@ -72,7 +72,7 @@ public class LoggingBenchmarkExecutionListener
             LOG.info("Query finished: {} ({}/{}), rows count: {}, duration: {}",
                     result.getQueryName(),
                     result.getQueryExecution().getSequenceId(),
-                    result.getBenchmark().getRuns(),
+                    result.getBenchmark().getRuns() * result.getBenchmark().getQueryRuns(),
                     result.getRowsCount(),
                     result.getQueryDuration());
         }
@@ -80,7 +80,7 @@ public class LoggingBenchmarkExecutionListener
             LOG.error("Query failed: {} ({}/{}), execution error: {}",
                     result.getQueryName(),
                     result.getQueryExecution().getSequenceId(),
-                    result.getBenchmark().getRuns(),
+                    result.getBenchmark().getRuns() * result.getBenchmark().getQueryRuns(),
                     result.getFailureCause().getMessage());
         }
 

--- a/benchto-driver/src/main/java/io/trino/benchto/driver/loader/BenchmarkDescriptor.java
+++ b/benchto-driver/src/main/java/io/trino/benchto/driver/loader/BenchmarkDescriptor.java
@@ -31,6 +31,7 @@ public class BenchmarkDescriptor
     public static final String DATA_SOURCE_KEY = "datasource";
     public static final String QUERY_NAMES_KEY = "query-names";
     public static final String RUNS_KEY = "runs";
+    public static final String QUERY_RUNS_KEY = "query-runs";
     public static final String PREWARM_RUNS_KEY = "prewarm-runs";
     public static final String CONCURRENCY_KEY = "concurrency";
     public static final String BEFORE_BENCHMARK_MACROS_KEY = "before-benchmark";
@@ -48,6 +49,7 @@ public class BenchmarkDescriptor
             DATA_SOURCE_KEY,
             QUERY_NAMES_KEY,
             RUNS_KEY,
+            QUERY_RUNS_KEY,
             PREWARM_RUNS_KEY,
             CONCURRENCY_KEY,
             BEFORE_BENCHMARK_MACROS_KEY,
@@ -91,6 +93,11 @@ public class BenchmarkDescriptor
     public Optional<Integer> getRuns()
     {
         return getIntegerOptional(RUNS_KEY);
+    }
+
+    public Optional<Integer> getQueryRuns()
+    {
+        return getIntegerOptional(QUERY_RUNS_KEY);
     }
 
     public Optional<Integer> getPrewarmRuns()

--- a/benchto-driver/src/main/java/io/trino/benchto/driver/loader/BenchmarkLoader.java
+++ b/benchto-driver/src/main/java/io/trino/benchto/driver/loader/BenchmarkLoader.java
@@ -74,7 +74,8 @@ public class BenchmarkLoader
 
     private static final String BENCHMARK_FILE_SUFFIX = "yaml";
 
-    private static final int DEFAULT_RUNS = 3;
+    private static final int DEFAULT_RUNS = 1;
+    private static final int DEFAULT_QUERY_RUNS = 3;
     private static final int DEFAULT_CONCURRENCY = 1;
     private static final int DEFAULT_PREWARM_RUNS = 0;
 
@@ -226,6 +227,7 @@ public class BenchmarkLoader
                         .withDataSource(benchmarkDescriptor.getDataSource())
                         .withEnvironment(properties.getEnvironmentName())
                         .withRuns(benchmarkDescriptor.getRuns().orElse(DEFAULT_RUNS))
+                        .withQueryRuns(benchmarkDescriptor.getQueryRuns().orElse(DEFAULT_QUERY_RUNS))
                         .withPrewarmRuns(benchmarkDescriptor.getPrewarmRuns().orElse(DEFAULT_PREWARM_RUNS))
                         .withConcurrency(benchmarkDescriptor.getConcurrency().orElse(DEFAULT_CONCURRENCY))
                         .withFrequency(benchmarkDescriptor.getFrequency().map(Duration::ofDays))
@@ -405,12 +407,13 @@ public class BenchmarkLoader
 
     private void printFormattedBenchmarksInfo(String formatString, Collection<Benchmark> benchmarks)
     {
-        LOGGER.info(format(formatString, "Benchmark Name", "Data Source", "Runs", "Prewarms", "Concurrency", "Throughput Test"));
+        LOGGER.info(format(formatString, "Benchmark Name", "Data Source", "Runs", "Query Runs", "Prewarms", "Concurrency", "Throughput Test"));
         benchmarks.stream()
                 .map(benchmark -> format(formatString,
                         benchmark.getName(),
                         benchmark.getDataSource(),
                         benchmark.getRuns() + "",
+                        benchmark.getQueryRuns() + "",
                         benchmark.getPrewarmRuns() + "",
                         benchmark.getConcurrency() + "",
                         benchmark.isThroughputTest() + ""))
@@ -423,6 +426,6 @@ public class BenchmarkLoader
         int nameMaxLength = benchmarks.stream().mapToInt((benchmark) -> benchmark.getName().length()).max().orElse(10);
         int dataSourceMaxLength = benchmarks.stream().mapToInt((benchmark) -> benchmark.getDataSource().length()).max().orElse(10);
         int indent = 3;
-        return "\t| %-" + (nameMaxLength + indent) + "s | %-" + Math.max(dataSourceMaxLength + indent, 11) + "s | %-4s | %-8s | %-11s | %-15s |";
+        return "\t| %-" + (nameMaxLength + indent) + "s | %-" + Math.max(dataSourceMaxLength + indent, 11) + "s | %-4s | %-10s | %-8s | %-11s | %-15s |";
     }
 }

--- a/benchto-driver/src/test/java/io/trino/benchto/driver/DriverAppIntegrationTest.java
+++ b/benchto-driver/src/test/java/io/trino/benchto/driver/DriverAppIntegrationTest.java
@@ -112,6 +112,24 @@ public class DriverAppIntegrationTest
         verifyComplete(allRuns);
     }
 
+    @Test
+    public void simpleSelectBenchmarkWithRepeatQueries()
+    {
+        setBenchmark("benchmark_with_2_queries");
+        verifyBenchmarkStart("benchmark_with_2_queries", "benchmark_with_2_queries_schema=INFORMATION_SCHEMA");
+        verifySerialExecution("benchmark_with_2_queries_schema=INFORMATION_SCHEMA", "simple_select", 1);
+        verifySerialExecution("benchmark_with_2_queries_schema=INFORMATION_SCHEMA", "simple_select", 2);
+        verifySerialExecution("benchmark_with_2_queries_schema=INFORMATION_SCHEMA", "simple_select_2", 1);
+        verifySerialExecution("benchmark_with_2_queries_schema=INFORMATION_SCHEMA", "simple_select_2", 2);
+        verifySerialExecution("benchmark_with_2_queries_schema=INFORMATION_SCHEMA", "simple_select", 3);
+        verifySerialExecution("benchmark_with_2_queries_schema=INFORMATION_SCHEMA", "simple_select", 4);
+        verifySerialExecution("benchmark_with_2_queries_schema=INFORMATION_SCHEMA", "simple_select_2", 3);
+        verifySerialExecution("benchmark_with_2_queries_schema=INFORMATION_SCHEMA", "simple_select_2", 4);
+
+        verifyBenchmarkFinish("benchmark_with_2_queries_schema=INFORMATION_SCHEMA", ImmutableList.of());
+        verifyComplete(10);
+    }
+
     private void setBenchmark(String s)
     {
         ReflectionTestUtils.setField(benchmarkProperties, "activeBenchmarks", s);

--- a/benchto-driver/src/test/java/io/trino/benchto/driver/execution/BenchmarkExecutionDriverTest.java
+++ b/benchto-driver/src/test/java/io/trino/benchto/driver/execution/BenchmarkExecutionDriverTest.java
@@ -83,6 +83,7 @@ public class BenchmarkExecutionDriverTest
     {
         Benchmark benchmark = mock(Benchmark.class);
         when(benchmark.getRuns()).thenReturn(1);
+        when(benchmark.getQueryRuns()).thenReturn(1);
         when(benchmark.getConcurrency()).thenReturn(1);
         when(benchmark.getQueries()).thenReturn(List.of(new Query("fake-query", "SELECT 1", Map.of())));
         List<BenchmarkExecutionResult> results = driver.execute(List.of(benchmark), 0, 0, Optional.empty());

--- a/benchto-driver/src/test/java/io/trino/benchto/driver/loader/BenchmarkLoaderTest.java
+++ b/benchto-driver/src/test/java/io/trino/benchto/driver/loader/BenchmarkLoaderTest.java
@@ -118,7 +118,7 @@ public class BenchmarkLoaderTest
         assertThat(benchmark.getName()).isEqualTo("different-than-filename");
         assertThat(benchmark.getQueries()).extracting("name").containsExactly("q1", "q2", "1", "2");
         assertThat(benchmark.getDataSource()).isEqualTo("foo");
-        assertThat(benchmark.getRuns()).isEqualTo(3);
+        assertThat(benchmark.getRuns()).isEqualTo(1);
         assertThat(benchmark.getConcurrency()).isEqualTo(1);
         assertThat(benchmark.getBeforeBenchmarkMacros()).isEqualTo(ImmutableList.of("no-op", "no-op2"));
         assertThat(benchmark.getAfterBenchmarkMacros()).isEqualTo(ImmutableList.of("no-op2"));

--- a/benchto-driver/src/test/resources/benchmarks/benchmark_with_2_queries.yaml
+++ b/benchto-driver/src/test/resources/benchmarks/benchmark_with_2_queries.yaml
@@ -1,10 +1,12 @@
 datasource: test_datasource
-query-names: test_query_failure.sql
+runs: 2
+query-runs: 2
+query-names: presto/simple_select.sql, presto/simple_select_2.sql
 before-benchmark: no-op-before-benchmark, test_query_before_benchmark.sql
 after-benchmark: no-op-after-benchmark
 before-execution: no-op-before-execution
 after-execution: no-op-after-execution
 prewarm-runs: 1
-runs: 1
-query-runs: 2
-
+variables:
+  1:
+    schema: INFORMATION_SCHEMA

--- a/benchto-driver/src/test/resources/benchmarks/simple_select_benchmark.yaml
+++ b/benchto-driver/src/test/resources/benchmarks/simple_select_benchmark.yaml
@@ -1,5 +1,6 @@
 datasource: test_datasource
-runs: 2
+runs: 1
+query-runs: 2
 query-names: presto/simple_select.sql
 before-benchmark: no-op-before-benchmark, test_query_before_benchmark.sql
 after-benchmark: no-op-after-benchmark

--- a/benchto-driver/src/test/resources/benchmarks/test_benchmark.yaml
+++ b/benchto-driver/src/test/resources/benchmarks/test_benchmark.yaml
@@ -5,4 +5,5 @@ after-benchmark: no-op-after-benchmark
 before-execution: no-op-before-execution
 after-execution: no-op-after-execution
 prewarm-runs: 1
-runs: 2
+runs: 1
+query-runs: 2

--- a/benchto-driver/src/test/resources/benchmarks/test_concurrent_benchmark.yaml
+++ b/benchto-driver/src/test/resources/benchmarks/test_concurrent_benchmark.yaml
@@ -4,6 +4,7 @@ before-benchmark: no-op-before-benchmark, test_query_before_benchmark.sql
 after-benchmark: no-op-after-benchmark
 before-execution: no-op-before-execution
 after-execution: no-op-after-execution
-runs: 1000
+runs: 1
+query-runs: 1000
 prewarm-runs: 1
 concurrency: 2

--- a/benchto-driver/src/test/resources/sql/presto/simple_select_2.sql
+++ b/benchto-driver/src/test/resources/sql/presto/simple_select_2.sql
@@ -1,0 +1,1 @@
+SELECT 2 FROM "${schema}".SYSTEM_USERS

--- a/benchto-it/src/test/resources/benchmarks/insert_test_results.yaml
+++ b/benchto-it/src/test/resources/benchmarks/insert_test_results.yaml
@@ -7,6 +7,7 @@ before-execution: create_insert_table.sql
 after-execution: no-op-after-execution
 prewarm-runs: 0
 runs: 1
+query-runs: 1
 variables:
   1:
     query: insert_test_query

--- a/benchto-it/src/test/resources/benchmarks/insert_test_results_failure.yaml
+++ b/benchto-it/src/test/resources/benchmarks/insert_test_results_failure.yaml
@@ -7,6 +7,7 @@ before-execution: create_insert_table.sql
 after-execution: no-op-after-execution
 prewarm-runs: 0
 runs: 1
+query-runs: 1
 variables:
   1:
     query: insert_test_query

--- a/benchto-it/src/test/resources/benchmarks/insert_test_results_failure_with_prewarm.yaml
+++ b/benchto-it/src/test/resources/benchmarks/insert_test_results_failure_with_prewarm.yaml
@@ -7,6 +7,7 @@ before-execution: create_insert_table.sql
 after-execution: no-op-after-execution
 prewarm-runs: 2
 runs: 1
+query-runs: 1
 variables:
   1:
     query: insert_test_query

--- a/benchto-it/src/test/resources/benchmarks/test_benchmark.yaml
+++ b/benchto-it/src/test/resources/benchmarks/test_benchmark.yaml
@@ -5,4 +5,5 @@ after-benchmark: no-op-after-benchmark
 before-execution: no-op-before-execution
 after-execution: no-op-after-execution
 prewarm-runs: 1
-runs: 2
+runs: 1
+query-runs: 2

--- a/benchto-it/src/test/resources/benchmarks/test_results.yaml
+++ b/benchto-it/src/test/resources/benchmarks/test_results.yaml
@@ -6,7 +6,8 @@ after-benchmark: no-op-after-benchmark
 before-execution: no-op-before-execution
 after-execution: no-op-after-execution
 prewarm-runs: 1
-runs: 2
+runs: 1
+query-runs: 2
 variables:
   1:
     query: test_results

--- a/benchto-it/src/test/resources/benchmarks/test_results_failure.yaml
+++ b/benchto-it/src/test/resources/benchmarks/test_results_failure.yaml
@@ -6,4 +6,5 @@ after-benchmark: no-op-after-benchmark
 before-execution: no-op-before-execution
 after-execution: no-op-after-execution
 prewarm-runs: 1
-runs: 2
+runs: 1
+query-runs: 2

--- a/benchto-it/src/test/resources/benchmarks/test_results_missing.yaml
+++ b/benchto-it/src/test/resources/benchmarks/test_results_missing.yaml
@@ -6,4 +6,6 @@ after-benchmark: no-op-after-benchmark
 before-execution: no-op-before-execution
 after-execution: no-op-after-execution
 prewarm-runs: 1
-runs: 2
+runs: 1
+query-runs: 2
+

--- a/benchto-it/src/test/resources/benchmarks/test_throughput_test.yaml
+++ b/benchto-it/src/test/resources/benchmarks/test_throughput_test.yaml
@@ -8,7 +8,8 @@ after-execution: no-op-after-execution
 throughput-test: true
 prewarm-runs: 1
 concurrency: 4
-runs: 4
+runs: 1
+query-runs: 4
 variables:
   1:
     query: test_results


### PR DESCRIPTION
It was added `query-runs` parameter that makes it possible to specify how many times particular query should be executed in a row.